### PR TITLE
Fix default docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ services:
       POSTGRES_USER: gameap
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-gameap}
     volumes:
-      - postgres-data:/var/lib/postgresql/data
+      - gameap-postgres-data:/var/lib/postgresql/data
     networks:
       - gameap-network
     restart: unless-stopped
@@ -62,7 +62,7 @@ services:
     container_name: gameap-redis
     command: redis-server --appendonly yes
     volumes:
-      - redis-data:/data
+      - gameap-redis-data:/data
     networks:
       - gameap-network
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
         VERSION: dev
         BUILD_DATE: ${BUILD_DATE:-2025-01-01T00:00:00Z}
     container_name: gameap
+    entrypoint: ["/bin/sh", "-c", "mkdir -p /var/lib/gameap/files && /usr/bin/gameap"]
     ports:
       - "8025:8025"
     environment:


### PR DESCRIPTION
When I clone the repo and use `docker-compose up -d`, said the next error:
```
service "postgres" refers to undefined volume postgres-data: invalid compose project
```
And was only becausethe volumes has diferent names
Then, `gameap` has errors because the bas path directory isn't created at the start:
```bash
panic: failed to open root directory: open /var/lib/gameap/files: no such file or directory

goroutine 1 [running]:
github.com/gameap/gameap/internal/files.NewLocalFileManager({0x2d21459a6016?, 0x1cf1458?})
/app/internal/files/local.go:25 +0xa5
github.com/gameap/gameap/internal/application.(*Container).createFileManager(0x0?)
/app/internal/application/container.go:845 +0xf4
github.com/gameap/gameap/internal/application.(*Container).FileManager(...)
/app/internal/application/container.go:827
github.com/gameap/gameap/internal/application.(*Container).CertificatesService(0x2d214595ce00)
/app/internal/application/container.go:882 +0x39
github.com/gameap/gameap/internal/application.seedClientCertificates({0x1ce5010, 0x2d2145ae91d0}, 0x2d214595ce00)
/app/internal/application/seeder.go:58 +0xe5
github.com/gameap/gameap/internal/application.seed({0x1ce5010, 0x2d2145ae91d0}, 0x2d214595ce00)
/app/internal/application/seeder.go:22 +0x26
github.com/gameap/gameap/internal/application.Run({{0x0?, 0x1ce4590?}, {0x18741f5?, 0x0?}})
/app/internal/application/application.go:98 +0x3e5
main.main()
/app/cmd/gameap/main.go:23 +0x116
2026/03/18 22:20:25 INFO Starting ...
panic: failed to open root directory: open /var/lib/gameap/files: no such file or directory
```