### PR TITLE
Fix file-manager copy-paste

### DIFF
--- a/internal/api/filemanager/paste/handler.go
+++ b/internal/api/filemanager/paste/handler.go
@@ -181,74 +181,41 @@ func (h *Handler) processItems(
 		return api.WrapHTTPError(err, http.StatusBadRequest)
 	}
 
+	sourceBase := filepath.Join(node.WorkPath, serverDir)
 	destinationBase := filepath.Join(node.WorkPath, serverDir, destPath)
 
+	operations := make([]pasteOperation, 0, len(req.Clipboard.Files)+len(req.Clipboard.Directories))
+
 	for _, rawFilePath := range req.Clipboard.Files {
-		filePath := strings.ReplaceAll(rawFilePath, "\\", "/")
-		if err := filemanagerpath.ValidatePath(filePath); err != nil {
-			return api.WrapHTTPError(err, http.StatusBadRequest)
-		}
-
-		sourcePath := filepath.Join(node.WorkPath, serverDir, filePath)
-
-		name, err := destinationName(rawFilePath, filePath, req.Names)
+		operation, ok, err := planPasteItem(sourceBase, destinationBase, rawFilePath, false, req)
 		if err != nil {
 			return err
 		}
 
-		destinationPath := filepath.Join(destinationBase, name)
-
-		if sourcePath == destinationPath {
-			if req.Clipboard.Type == operationTypeCut {
-				continue
-			}
-
-			return api.WrapHTTPError(
-				errors.Errorf("copy source and destination are the same: %s", filePath),
-				http.StatusBadRequest,
-			)
-		}
-
-		if err := h.pasteItem(ctx, node, sourcePath, destinationPath, req.Clipboard.Type); err != nil {
-			return errors.WithMessagef(err, "failed to paste file: %s", filePath)
+		if ok {
+			operations = append(operations, operation)
 		}
 	}
 
 	for _, rawDirPath := range req.Clipboard.Directories {
-		dirPath := strings.ReplaceAll(rawDirPath, "\\", "/")
-		if err := filemanagerpath.ValidatePath(dirPath); err != nil {
-			return api.WrapHTTPError(err, http.StatusBadRequest)
-		}
-
-		sourcePath := filepath.Join(node.WorkPath, serverDir, dirPath)
-
-		if pathIsInside(destinationBase, sourcePath) {
-			return api.WrapHTTPError(
-				errors.Errorf("cannot paste directory %s into itself", dirPath),
-				http.StatusBadRequest,
-			)
-		}
-
-		name, err := destinationName(rawDirPath, dirPath, req.Names)
+		operation, ok, err := planPasteItem(sourceBase, destinationBase, rawDirPath, true, req)
 		if err != nil {
 			return err
 		}
 
-		destinationPath := filepath.Join(destinationBase, name)
+		if ok {
+			operations = append(operations, operation)
+		}
+	}
 
-		if sourcePath == destinationPath {
-			if req.Clipboard.Type == operationTypeCut {
-				continue
+	for _, operation := range operations {
+		if err := h.pasteItem(ctx, node, operation.source, operation.destination, req.Clipboard.Type); err != nil {
+			itemKind := "file"
+			if operation.isDir {
+				itemKind = "directory"
 			}
 
-			return api.WrapHTTPError(
-				errors.Errorf("copy source and destination are the same: %s", dirPath),
-				http.StatusBadRequest,
-			)
-		}
-
-		if err := h.pasteItem(ctx, node, sourcePath, destinationPath, req.Clipboard.Type); err != nil {
-			return errors.WithMessagef(err, "failed to paste directory: %s", dirPath)
+			return errors.WithMessagef(err, "failed to paste %s: %s", itemKind, operation.itemPath)
 		}
 	}
 
@@ -270,6 +237,67 @@ func (h *Handler) pasteItem(
 	default:
 		return errors.Errorf("unknown operation type: %s", operationType)
 	}
+}
+
+// pasteOperation is a validated copy/move planned for execution. The whole
+// request is planned before the first daemon call so a validation error in
+// any item rejects the batch without partially applying it.
+type pasteOperation struct {
+	source      string
+	destination string
+	itemPath    string
+	isDir       bool
+}
+
+// planPasteItem validates one clipboard item and resolves its operation.
+// ok is false for a same-path move, which is skipped as a no-op.
+func planPasteItem(
+	sourceBase string,
+	destinationBase string,
+	rawPath string,
+	isDir bool,
+	req *pasteRequest,
+) (pasteOperation, bool, error) {
+	itemPath := strings.ReplaceAll(rawPath, "\\", "/")
+	if err := filemanagerpath.ValidatePath(itemPath); err != nil {
+		return pasteOperation{}, false, api.WrapHTTPError(err, http.StatusBadRequest)
+	}
+
+	sourcePath := filepath.Join(sourceBase, itemPath)
+
+	if isDir && pathIsInside(destinationBase, sourcePath) {
+		return pasteOperation{}, false, api.WrapHTTPError(
+			errors.Errorf("cannot paste directory %s into itself", itemPath),
+			http.StatusBadRequest,
+		)
+	}
+
+	name, err := destinationName(rawPath, itemPath, req.Names)
+	if err != nil {
+		return pasteOperation{}, false, err
+	}
+
+	destinationPath := filepath.Join(destinationBase, name)
+
+	if sourcePath == destinationPath {
+		if req.Clipboard.Type == operationTypeCut {
+			return pasteOperation{}, false, nil
+		}
+
+		return pasteOperation{}, false, api.WrapHTTPError(
+			errors.Errorf("copy source and destination are the same: %s", itemPath),
+			http.StatusBadRequest,
+		)
+	}
+
+	operation := pasteOperation{
+		source:      sourcePath,
+		destination: destinationPath,
+		itemPath:    itemPath,
+		isDir:       isDir,
+	}
+
+	return operation, true, nil
 }
 
 // destinationName returns the basename an item is pasted under: the override

--- a/internal/api/filemanager/paste/handler.go
+++ b/internal/api/filemanager/paste/handler.go
@@ -190,7 +190,24 @@ func (h *Handler) processItems(
 		}
 
 		sourcePath := filepath.Join(node.WorkPath, serverDir, filePath)
-		destinationPath := filepath.Join(destinationBase, path.Base(filePath))
+
+		name, err := destinationName(rawFilePath, filePath, req.Names)
+		if err != nil {
+			return err
+		}
+
+		destinationPath := filepath.Join(destinationBase, name)
+
+		if sourcePath == destinationPath {
+			if req.Clipboard.Type == operationTypeCut {
+				continue
+			}
+
+			return api.WrapHTTPError(
+				errors.Errorf("copy source and destination are the same: %s", filePath),
+				http.StatusBadRequest,
+			)
+		}
 
 		if err := h.pasteItem(ctx, node, sourcePath, destinationPath, req.Clipboard.Type); err != nil {
 			return errors.WithMessagef(err, "failed to paste file: %s", filePath)
@@ -204,7 +221,31 @@ func (h *Handler) processItems(
 		}
 
 		sourcePath := filepath.Join(node.WorkPath, serverDir, dirPath)
-		destinationPath := filepath.Join(destinationBase, path.Base(dirPath))
+
+		if pathIsInside(destinationBase, sourcePath) {
+			return api.WrapHTTPError(
+				errors.Errorf("cannot paste directory %s into itself", dirPath),
+				http.StatusBadRequest,
+			)
+		}
+
+		name, err := destinationName(rawDirPath, dirPath, req.Names)
+		if err != nil {
+			return err
+		}
+
+		destinationPath := filepath.Join(destinationBase, name)
+
+		if sourcePath == destinationPath {
+			if req.Clipboard.Type == operationTypeCut {
+				continue
+			}
+
+			return api.WrapHTTPError(
+				errors.Errorf("copy source and destination are the same: %s", dirPath),
+				http.StatusBadRequest,
+			)
+		}
 
 		if err := h.pasteItem(ctx, node, sourcePath, destinationPath, req.Clipboard.Type); err != nil {
 			return errors.WithMessagef(err, "failed to paste directory: %s", dirPath)
@@ -229,4 +270,24 @@ func (h *Handler) pasteItem(
 	default:
 		return errors.Errorf("unknown operation type: %s", operationType)
 	}
+}
+
+// destinationName returns the basename an item is pasted under: the override
+// from names (keyed by the raw clipboard entry) or the item's own basename.
+func destinationName(rawPath, normalizedPath string, names map[string]string) (string, error) {
+	name, ok := names[rawPath]
+	if !ok {
+		return path.Base(normalizedPath), nil
+	}
+
+	if err := filemanagerpath.ValidateFilename(name); err != nil {
+		return "", api.WrapHTTPError(err, http.StatusBadRequest)
+	}
+
+	return name, nil
+}
+
+// pathIsInside reports whether child is parent itself or located inside it.
+func pathIsInside(child, parent string) bool {
+	return child == parent || strings.HasPrefix(child, parent+string(filepath.Separator))
 }

--- a/internal/api/filemanager/paste/handler_test.go
+++ b/internal/api/filemanager/paste/handler_test.go
@@ -69,8 +69,10 @@ var testNode = domain.Node{
 }
 
 type mockFileService struct {
-	copyFunc func(ctx context.Context, node *domain.Node, source, destination string) error
-	moveFunc func(ctx context.Context, node *domain.Node, source, destination string) error
+	copyFunc  func(ctx context.Context, node *domain.Node, source, destination string) error
+	moveFunc  func(ctx context.Context, node *domain.Node, source, destination string) error
+	copyCalls int
+	moveCalls int
 }
 
 func (m *mockFileService) Copy(
@@ -79,6 +81,8 @@ func (m *mockFileService) Copy(
 	source string,
 	destination string,
 ) error {
+	m.copyCalls++
+
 	if m.copyFunc != nil {
 		return m.copyFunc(ctx, node, source, destination)
 	}
@@ -92,6 +96,8 @@ func (m *mockFileService) Move(
 	source string,
 	destination string,
 ) error {
+	m.moveCalls++
+
 	if m.moveFunc != nil {
 		return m.moveFunc(ctx, node, source, destination)
 	}
@@ -156,6 +162,8 @@ func TestHandler_ServeHTTP(t *testing.T) {
 		setupFileService func() *mockFileService
 		expectedStatus   int
 		wantError        string
+		wantCopyCalls    *int
+		wantMoveCalls    *int
 		validateResponse func(*testing.T, []byte)
 	}{
 		{
@@ -1499,6 +1507,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 				}
 			},
 			expectedStatus: http.StatusOK,
+			wantCopyCalls:  new(1),
 			validateResponse: func(t *testing.T, body []byte) {
 				t.Helper()
 
@@ -1541,6 +1550,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 				}
 			},
 			expectedStatus: http.StatusOK,
+			wantCopyCalls:  new(1),
 			validateResponse: func(t *testing.T, body []byte) {
 				t.Helper()
 
@@ -1582,6 +1592,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 				}
 			},
 			expectedStatus: http.StatusOK,
+			wantCopyCalls:  new(1),
 			validateResponse: func(t *testing.T, body []byte) {
 				t.Helper()
 
@@ -1621,6 +1632,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 				}
 			},
 			expectedStatus: http.StatusOK,
+			wantMoveCalls:  new(0),
 			validateResponse: func(t *testing.T, body []byte) {
 				t.Helper()
 
@@ -1661,6 +1673,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 				}
 			},
 			expectedStatus: http.StatusOK,
+			wantMoveCalls:  new(0),
 			validateResponse: func(t *testing.T, body []byte) {
 				t.Helper()
 
@@ -1706,6 +1719,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 				}
 			},
 			expectedStatus: http.StatusOK,
+			wantMoveCalls:  new(1),
 			validateResponse: func(t *testing.T, body []byte) {
 				t.Helper()
 
@@ -1967,6 +1981,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 				}
 			},
 			expectedStatus: http.StatusOK,
+			wantCopyCalls:  new(2),
 			validateResponse: func(t *testing.T, body []byte) {
 				t.Helper()
 
@@ -1975,6 +1990,35 @@ func TestHandler_ServeHTTP(t *testing.T) {
 				assert.Equal(t, "success", response.Result.Status)
 				assert.Equal(t, "Copied successfully!", response.Result.Message)
 			},
+		},
+		{
+			name:     "invalid_item_aborts_batch_before_any_operation",
+			serverID: "1",
+			requestBody: pasteRequest{
+				Disk: "server",
+				Path: "backup",
+				Clipboard: clipboard{
+					Type:        "copy",
+					Disk:        "server",
+					Directories: []string{},
+					Files:       []string{"a.txt", "docs/b.txt"},
+				},
+				Names: map[string]string{"docs/b.txt": "sub/b.txt"},
+			},
+			setupAuth: testUser1Session,
+			setupRepo: func(
+				serverRepo *inmemory.ServerRepository,
+				nodeRepo *inmemory.NodeRepository,
+				rbacRepo *inmemory.RBACRepository,
+			) {
+				setupServer1WithNode(t, serverRepo, nodeRepo, rbacRepo)
+			},
+			setupFileService: func() *mockFileService {
+				return &mockFileService{}
+			},
+			expectedStatus: http.StatusBadRequest,
+			wantError:      "filename contains path separators",
+			wantCopyCalls:  new(0),
 		},
 	}
 
@@ -2019,6 +2063,14 @@ func TestHandler_ServeHTTP(t *testing.T) {
 				errorMsg, ok := response["error"].(string)
 				require.True(t, ok)
 				assert.Contains(t, errorMsg, tt.wantError)
+			}
+
+			if tt.wantCopyCalls != nil {
+				assert.Equal(t, *tt.wantCopyCalls, fileService.copyCalls, "unexpected Copy call count")
+			}
+
+			if tt.wantMoveCalls != nil {
+				assert.Equal(t, *tt.wantMoveCalls, fileService.moveCalls, "unexpected Move call count")
 			}
 
 			if tt.validateResponse != nil {

--- a/internal/api/filemanager/paste/handler_test.go
+++ b/internal/api/filemanager/paste/handler_test.go
@@ -99,6 +99,53 @@ func (m *mockFileService) Move(
 	return nil
 }
 
+func testUser1Session() context.Context {
+	session := &auth.Session{
+		Login: "testuser",
+		Email: "test@example.com",
+		User:  &testUser1,
+	}
+
+	return auth.ContextWithSession(context.Background(), session)
+}
+
+func setupServer1WithNode(
+	t *testing.T,
+	serverRepo *inmemory.ServerRepository,
+	nodeRepo *inmemory.NodeRepository,
+	rbacRepo *inmemory.RBACRepository,
+) {
+	t.Helper()
+
+	now := time.Now()
+
+	server := &domain.Server{
+		ID:            1,
+		UID:           uuid.MustParse("11111111-1111-1111-1111-111111111111"),
+		UUIDShort:     "short1",
+		Enabled:       true,
+		Installed:     1,
+		Blocked:       false,
+		Name:          "Test Server 1",
+		GameID:        "cs",
+		DSID:          1,
+		GameModID:     1,
+		ServerIP:      "127.0.0.1",
+		ServerPort:    27015,
+		Dir:           "servers/test1",
+		ProcessActive: false,
+		CreatedAt:     &now,
+		UpdatedAt:     &now,
+	}
+
+	require.NoError(t, serverRepo.Save(context.Background(), server))
+	serverRepo.AddUserServer(1, 1)
+	allowUserFilesAbility(t, rbacRepo, 1, 1)
+
+	node := testNode
+	require.NoError(t, nodeRepo.Save(context.Background(), &node))
+}
+
 func TestHandler_ServeHTTP(t *testing.T) {
 	tests := []struct {
 		name             string
@@ -1384,6 +1431,549 @@ func TestHandler_ServeHTTP(t *testing.T) {
 				var response pasteResponse
 				require.NoError(t, json.Unmarshal(body, &response))
 				assert.Equal(t, "success", response.Result.Status)
+			},
+		},
+		{
+			name:     "copy_to_same_directory_without_rename",
+			serverID: "1",
+			requestBody: pasteRequest{
+				Disk: "server",
+				Path: "docs",
+				Clipboard: clipboard{
+					Type:        "copy",
+					Disk:        "server",
+					Directories: []string{},
+					Files:       []string{"docs/report.txt"},
+				},
+			},
+			setupAuth: testUser1Session,
+			setupRepo: func(
+				serverRepo *inmemory.ServerRepository,
+				nodeRepo *inmemory.NodeRepository,
+				rbacRepo *inmemory.RBACRepository,
+			) {
+				setupServer1WithNode(t, serverRepo, nodeRepo, rbacRepo)
+			},
+			setupFileService: func() *mockFileService {
+				return &mockFileService{
+					copyFunc: func(_ context.Context, _ *domain.Node, source string, destination string) error {
+						t.Errorf("Copy must not be called, got %s -> %s", source, destination)
+
+						return nil
+					},
+				}
+			},
+			expectedStatus: http.StatusBadRequest,
+			wantError:      "copy source and destination are the same",
+		},
+		{
+			name:     "copy_to_same_directory_with_rename_suffix",
+			serverID: "1",
+			requestBody: pasteRequest{
+				Disk: "server",
+				Path: "docs",
+				Clipboard: clipboard{
+					Type:        "copy",
+					Disk:        "server",
+					Directories: []string{},
+					Files:       []string{"docs/report.txt"},
+				},
+				Names: map[string]string{"docs/report.txt": "report_1.txt"},
+			},
+			setupAuth: testUser1Session,
+			setupRepo: func(
+				serverRepo *inmemory.ServerRepository,
+				nodeRepo *inmemory.NodeRepository,
+				rbacRepo *inmemory.RBACRepository,
+			) {
+				setupServer1WithNode(t, serverRepo, nodeRepo, rbacRepo)
+			},
+			setupFileService: func() *mockFileService {
+				return &mockFileService{
+					copyFunc: func(_ context.Context, _ *domain.Node, source string, destination string) error {
+						assert.Equal(t, "/srv/gameap/servers/test1/docs/report.txt", source)
+						assert.Equal(t, "/srv/gameap/servers/test1/docs/report_1.txt", destination)
+
+						return nil
+					},
+				}
+			},
+			expectedStatus: http.StatusOK,
+			validateResponse: func(t *testing.T, body []byte) {
+				t.Helper()
+
+				var response pasteResponse
+				require.NoError(t, json.Unmarshal(body, &response))
+				assert.Equal(t, "success", response.Result.Status)
+				assert.Equal(t, "Copied successfully!", response.Result.Message)
+			},
+		},
+		{
+			name:     "copy_windows_backslash_path_to_same_directory_with_rename_suffix",
+			serverID: "1",
+			requestBody: pasteRequest{
+				Disk: "server",
+				Path: "ioquake3",
+				Clipboard: clipboard{
+					Type:        "copy",
+					Disk:        "server",
+					Directories: []string{},
+					Files:       []string{"ioquake3\\SDL264.dll"},
+				},
+				Names: map[string]string{"ioquake3\\SDL264.dll": "SDL264_1.dll"},
+			},
+			setupAuth: testUser1Session,
+			setupRepo: func(
+				serverRepo *inmemory.ServerRepository,
+				nodeRepo *inmemory.NodeRepository,
+				rbacRepo *inmemory.RBACRepository,
+			) {
+				setupServer1WithNode(t, serverRepo, nodeRepo, rbacRepo)
+			},
+			setupFileService: func() *mockFileService {
+				return &mockFileService{
+					copyFunc: func(_ context.Context, _ *domain.Node, source string, destination string) error {
+						assert.Equal(t, "/srv/gameap/servers/test1/ioquake3/SDL264.dll", source)
+						assert.Equal(t, "/srv/gameap/servers/test1/ioquake3/SDL264_1.dll", destination)
+
+						return nil
+					},
+				}
+			},
+			expectedStatus: http.StatusOK,
+			validateResponse: func(t *testing.T, body []byte) {
+				t.Helper()
+
+				var response pasteResponse
+				require.NoError(t, json.Unmarshal(body, &response))
+				assert.Equal(t, "success", response.Result.Status)
+			},
+		},
+		{
+			name:     "copy_directory_to_same_directory_with_rename_suffix",
+			serverID: "1",
+			requestBody: pasteRequest{
+				Disk: "server",
+				Path: ".",
+				Clipboard: clipboard{
+					Type:        "copy",
+					Disk:        "server",
+					Directories: []string{"configs"},
+					Files:       []string{},
+				},
+				Names: map[string]string{"configs": "configs_1"},
+			},
+			setupAuth: testUser1Session,
+			setupRepo: func(
+				serverRepo *inmemory.ServerRepository,
+				nodeRepo *inmemory.NodeRepository,
+				rbacRepo *inmemory.RBACRepository,
+			) {
+				setupServer1WithNode(t, serverRepo, nodeRepo, rbacRepo)
+			},
+			setupFileService: func() *mockFileService {
+				return &mockFileService{
+					copyFunc: func(_ context.Context, _ *domain.Node, source string, destination string) error {
+						assert.Equal(t, "/srv/gameap/servers/test1/configs", source)
+						assert.Equal(t, "/srv/gameap/servers/test1/configs_1", destination)
+
+						return nil
+					},
+				}
+			},
+			expectedStatus: http.StatusOK,
+			validateResponse: func(t *testing.T, body []byte) {
+				t.Helper()
+
+				var response pasteResponse
+				require.NoError(t, json.Unmarshal(body, &response))
+				assert.Equal(t, "success", response.Result.Status)
+			},
+		},
+		{
+			name:     "cut_to_same_directory_is_noop",
+			serverID: "1",
+			requestBody: pasteRequest{
+				Disk: "server",
+				Path: "docs",
+				Clipboard: clipboard{
+					Type:        "cut",
+					Disk:        "server",
+					Directories: []string{},
+					Files:       []string{"docs/report.txt"},
+				},
+			},
+			setupAuth: testUser1Session,
+			setupRepo: func(
+				serverRepo *inmemory.ServerRepository,
+				nodeRepo *inmemory.NodeRepository,
+				rbacRepo *inmemory.RBACRepository,
+			) {
+				setupServer1WithNode(t, serverRepo, nodeRepo, rbacRepo)
+			},
+			setupFileService: func() *mockFileService {
+				return &mockFileService{
+					moveFunc: func(_ context.Context, _ *domain.Node, source string, destination string) error {
+						t.Errorf("Move must not be called, got %s -> %s", source, destination)
+
+						return nil
+					},
+				}
+			},
+			expectedStatus: http.StatusOK,
+			validateResponse: func(t *testing.T, body []byte) {
+				t.Helper()
+
+				var response pasteResponse
+				require.NoError(t, json.Unmarshal(body, &response))
+				assert.Equal(t, "success", response.Result.Status)
+				assert.Equal(t, "Moved successfully!", response.Result.Message)
+			},
+		},
+		{
+			name:     "cut_directory_to_same_directory_is_noop",
+			serverID: "1",
+			requestBody: pasteRequest{
+				Disk: "server",
+				Path: ".",
+				Clipboard: clipboard{
+					Type:        "cut",
+					Disk:        "server",
+					Directories: []string{"configs"},
+					Files:       []string{},
+				},
+			},
+			setupAuth: testUser1Session,
+			setupRepo: func(
+				serverRepo *inmemory.ServerRepository,
+				nodeRepo *inmemory.NodeRepository,
+				rbacRepo *inmemory.RBACRepository,
+			) {
+				setupServer1WithNode(t, serverRepo, nodeRepo, rbacRepo)
+			},
+			setupFileService: func() *mockFileService {
+				return &mockFileService{
+					moveFunc: func(_ context.Context, _ *domain.Node, source string, destination string) error {
+						t.Errorf("Move must not be called, got %s -> %s", source, destination)
+
+						return nil
+					},
+				}
+			},
+			expectedStatus: http.StatusOK,
+			validateResponse: func(t *testing.T, body []byte) {
+				t.Helper()
+
+				var response pasteResponse
+				require.NoError(t, json.Unmarshal(body, &response))
+				assert.Equal(t, "success", response.Result.Status)
+				assert.Equal(t, "Moved successfully!", response.Result.Message)
+			},
+		},
+		{
+			name:     "cut_mixed_items_moves_only_relocated_ones",
+			serverID: "1",
+			requestBody: pasteRequest{
+				Disk: "server",
+				Path: "new",
+				Clipboard: clipboard{
+					Type:        "cut",
+					Disk:        "server",
+					Directories: []string{},
+					Files:       []string{"new/a.txt", "b.txt"},
+				},
+			},
+			setupAuth: testUser1Session,
+			setupRepo: func(
+				serverRepo *inmemory.ServerRepository,
+				nodeRepo *inmemory.NodeRepository,
+				rbacRepo *inmemory.RBACRepository,
+			) {
+				setupServer1WithNode(t, serverRepo, nodeRepo, rbacRepo)
+			},
+			setupFileService: func() *mockFileService {
+				callCount := 0
+
+				return &mockFileService{
+					moveFunc: func(_ context.Context, _ *domain.Node, source string, destination string) error {
+						require.Equal(t, 0, callCount, "only one move expected")
+						assert.Equal(t, "/srv/gameap/servers/test1/b.txt", source)
+						assert.Equal(t, "/srv/gameap/servers/test1/new/b.txt", destination)
+						callCount++
+
+						return nil
+					},
+				}
+			},
+			expectedStatus: http.StatusOK,
+			validateResponse: func(t *testing.T, body []byte) {
+				t.Helper()
+
+				var response pasteResponse
+				require.NoError(t, json.Unmarshal(body, &response))
+				assert.Equal(t, "success", response.Result.Status)
+				assert.Equal(t, "Moved successfully!", response.Result.Message)
+			},
+		},
+		{
+			name:     "invalid_name_with_path_separator",
+			serverID: "1",
+			requestBody: pasteRequest{
+				Disk: "server",
+				Path: "backup",
+				Clipboard: clipboard{
+					Type:        "copy",
+					Disk:        "server",
+					Directories: []string{},
+					Files:       []string{"docs/report.txt"},
+				},
+				Names: map[string]string{"docs/report.txt": "sub/report.txt"},
+			},
+			setupAuth: testUser1Session,
+			setupRepo: func(
+				serverRepo *inmemory.ServerRepository,
+				nodeRepo *inmemory.NodeRepository,
+				rbacRepo *inmemory.RBACRepository,
+			) {
+				setupServer1WithNode(t, serverRepo, nodeRepo, rbacRepo)
+			},
+			setupFileService: func() *mockFileService {
+				return &mockFileService{
+					copyFunc: func(_ context.Context, _ *domain.Node, source string, destination string) error {
+						t.Errorf("Copy must not be called, got %s -> %s", source, destination)
+
+						return nil
+					},
+				}
+			},
+			expectedStatus: http.StatusBadRequest,
+			wantError:      "filename contains path separators",
+		},
+		{
+			name:     "invalid_name_with_directory_traversal",
+			serverID: "1",
+			requestBody: pasteRequest{
+				Disk: "server",
+				Path: "backup",
+				Clipboard: clipboard{
+					Type:        "copy",
+					Disk:        "server",
+					Directories: []string{},
+					Files:       []string{"docs/report.txt"},
+				},
+				Names: map[string]string{"docs/report.txt": ".."},
+			},
+			setupAuth: testUser1Session,
+			setupRepo: func(
+				serverRepo *inmemory.ServerRepository,
+				nodeRepo *inmemory.NodeRepository,
+				rbacRepo *inmemory.RBACRepository,
+			) {
+				setupServer1WithNode(t, serverRepo, nodeRepo, rbacRepo)
+			},
+			setupFileService: func() *mockFileService {
+				return &mockFileService{
+					copyFunc: func(_ context.Context, _ *domain.Node, source string, destination string) error {
+						t.Errorf("Copy must not be called, got %s -> %s", source, destination)
+
+						return nil
+					},
+				}
+			},
+			expectedStatus: http.StatusBadRequest,
+			wantError:      "filename contains invalid directory traversal",
+		},
+		{
+			name:     "invalid_empty_name",
+			serverID: "1",
+			requestBody: pasteRequest{
+				Disk: "server",
+				Path: "backup",
+				Clipboard: clipboard{
+					Type:        "copy",
+					Disk:        "server",
+					Directories: []string{},
+					Files:       []string{"docs/report.txt"},
+				},
+				Names: map[string]string{"docs/report.txt": ""},
+			},
+			setupAuth: testUser1Session,
+			setupRepo: func(
+				serverRepo *inmemory.ServerRepository,
+				nodeRepo *inmemory.NodeRepository,
+				rbacRepo *inmemory.RBACRepository,
+			) {
+				setupServer1WithNode(t, serverRepo, nodeRepo, rbacRepo)
+			},
+			setupFileService: func() *mockFileService {
+				return &mockFileService{
+					copyFunc: func(_ context.Context, _ *domain.Node, source string, destination string) error {
+						t.Errorf("Copy must not be called, got %s -> %s", source, destination)
+
+						return nil
+					},
+				}
+			},
+			expectedStatus: http.StatusBadRequest,
+			wantError:      "filename is empty",
+		},
+		{
+			name:     "directory_pasted_into_itself",
+			serverID: "1",
+			requestBody: pasteRequest{
+				Disk: "server",
+				Path: "configs",
+				Clipboard: clipboard{
+					Type:        "copy",
+					Disk:        "server",
+					Directories: []string{"configs"},
+					Files:       []string{},
+				},
+			},
+			setupAuth: testUser1Session,
+			setupRepo: func(
+				serverRepo *inmemory.ServerRepository,
+				nodeRepo *inmemory.NodeRepository,
+				rbacRepo *inmemory.RBACRepository,
+			) {
+				setupServer1WithNode(t, serverRepo, nodeRepo, rbacRepo)
+			},
+			setupFileService: func() *mockFileService {
+				return &mockFileService{
+					copyFunc: func(_ context.Context, _ *domain.Node, source string, destination string) error {
+						t.Errorf("Copy must not be called, got %s -> %s", source, destination)
+
+						return nil
+					},
+				}
+			},
+			expectedStatus: http.StatusBadRequest,
+			wantError:      "into itself",
+		},
+		{
+			name:     "directory_pasted_into_own_subdirectory",
+			serverID: "1",
+			requestBody: pasteRequest{
+				Disk: "server",
+				Path: "configs/nested",
+				Clipboard: clipboard{
+					Type:        "cut",
+					Disk:        "server",
+					Directories: []string{"configs"},
+					Files:       []string{},
+				},
+			},
+			setupAuth: testUser1Session,
+			setupRepo: func(
+				serverRepo *inmemory.ServerRepository,
+				nodeRepo *inmemory.NodeRepository,
+				rbacRepo *inmemory.RBACRepository,
+			) {
+				setupServer1WithNode(t, serverRepo, nodeRepo, rbacRepo)
+			},
+			setupFileService: func() *mockFileService {
+				return &mockFileService{
+					moveFunc: func(_ context.Context, _ *domain.Node, source string, destination string) error {
+						t.Errorf("Move must not be called, got %s -> %s", source, destination)
+
+						return nil
+					},
+				}
+			},
+			expectedStatus: http.StatusBadRequest,
+			wantError:      "into itself",
+		},
+		{
+			name:     "directory_pasted_into_itself_with_rename",
+			serverID: "1",
+			requestBody: pasteRequest{
+				Disk: "server",
+				Path: "configs",
+				Clipboard: clipboard{
+					Type:        "copy",
+					Disk:        "server",
+					Directories: []string{"configs"},
+					Files:       []string{},
+				},
+				Names: map[string]string{"configs": "configs_1"},
+			},
+			setupAuth: testUser1Session,
+			setupRepo: func(
+				serverRepo *inmemory.ServerRepository,
+				nodeRepo *inmemory.NodeRepository,
+				rbacRepo *inmemory.RBACRepository,
+			) {
+				setupServer1WithNode(t, serverRepo, nodeRepo, rbacRepo)
+			},
+			setupFileService: func() *mockFileService {
+				return &mockFileService{
+					copyFunc: func(_ context.Context, _ *domain.Node, source string, destination string) error {
+						t.Errorf("Copy must not be called, got %s -> %s", source, destination)
+
+						return nil
+					},
+				}
+			},
+			expectedStatus: http.StatusBadRequest,
+			wantError:      "into itself",
+		},
+		{
+			name:     "names_applied_only_to_listed_items",
+			serverID: "1",
+			requestBody: pasteRequest{
+				Disk: "server",
+				Path: "backup",
+				Clipboard: clipboard{
+					Type:        "copy",
+					Disk:        "server",
+					Directories: []string{},
+					Files:       []string{"a.txt", "docs/b.txt"},
+				},
+				Names: map[string]string{"docs/b.txt": "b_1.txt"},
+			},
+			setupAuth: testUser1Session,
+			setupRepo: func(
+				serverRepo *inmemory.ServerRepository,
+				nodeRepo *inmemory.NodeRepository,
+				rbacRepo *inmemory.RBACRepository,
+			) {
+				setupServer1WithNode(t, serverRepo, nodeRepo, rbacRepo)
+			},
+			setupFileService: func() *mockFileService {
+				callCount := 0
+				expectedCalls := []struct {
+					source      string
+					destination string
+				}{
+					{
+						source:      "/srv/gameap/servers/test1/a.txt",
+						destination: "/srv/gameap/servers/test1/backup/a.txt",
+					},
+					{
+						source:      "/srv/gameap/servers/test1/docs/b.txt",
+						destination: "/srv/gameap/servers/test1/backup/b_1.txt",
+					},
+				}
+
+				return &mockFileService{
+					copyFunc: func(_ context.Context, _ *domain.Node, source string, destination string) error {
+						require.Less(t, callCount, len(expectedCalls), "more calls than expected")
+						assert.Equal(t, expectedCalls[callCount].source, source)
+						assert.Equal(t, expectedCalls[callCount].destination, destination)
+						callCount++
+
+						return nil
+					},
+				}
+			},
+			expectedStatus: http.StatusOK,
+			validateResponse: func(t *testing.T, body []byte) {
+				t.Helper()
+
+				var response pasteResponse
+				require.NoError(t, json.Unmarshal(body, &response))
+				assert.Equal(t, "success", response.Result.Status)
+				assert.Equal(t, "Copied successfully!", response.Result.Message)
 			},
 		},
 	}

--- a/internal/api/filemanager/paste/request.go
+++ b/internal/api/filemanager/paste/request.go
@@ -1,9 +1,10 @@
 package paste
 
 type pasteRequest struct {
-	Disk      string    `json:"disk"`
-	Path      string    `json:"path"`
-	Clipboard clipboard `json:"clipboard"`
+	Disk      string            `json:"disk"`
+	Path      string            `json:"path"`
+	Clipboard clipboard         `json:"clipboard"`
+	Names     map[string]string `json:"names"`
 }
 
 type clipboard struct {

--- a/openapi/paths/file-manager.yaml
+++ b/openapi/paths/file-manager.yaml
@@ -761,7 +761,16 @@
     tags:
       - FileManager
     summary: Copy/move files
-    description: Copies or moves files/directories
+    description: |
+      Copies (`clipboard.type: copy`) or moves (`clipboard.type: cut`)
+      clipboard items into the `path` directory. All paths are relative to
+      the server root directory; backslash separators are normalized to
+      forward slashes. Each item lands in `path` under its own basename
+      unless `names` overrides it. Existing destination items are silently
+      overwritten. Copying an item onto itself is rejected — pass a new
+      basename via `names` to duplicate an item in its own directory. Moving
+      an item onto itself is skipped as a no-op. Pasting a directory into
+      itself or its own subtree is rejected.
     operationId: pasteFiles
     parameters:
       - name: server
@@ -777,22 +786,61 @@
           schema:
             type: object
             properties:
-              items:
-                type: array
-                description: Source paths
-                items:
+              disk:
+                type: string
+                description: Disk name, only `server` is supported
+                enum:
+                  - server
+              path:
+                type: string
+                description: >
+                  Destination directory relative to the server root
+                  directory; empty string or `/` means the root itself
+              clipboard:
+                type: object
+                description: Items to paste and the operation type
+                properties:
+                  type:
+                    type: string
+                    description: Operation type
+                    enum:
+                      - copy
+                      - cut
+                  disk:
+                    type: string
+                    description: Source disk name, only `server` is supported
+                    enum:
+                      - server
+                  directories:
+                    type: array
+                    description: Source directory paths relative to the server root
+                    items:
+                      type: string
+                  files:
+                    type: array
+                    description: Source file paths relative to the server root
+                    items:
+                      type: string
+                required:
+                  - type
+                  - disk
+                  - directories
+                  - files
+              names:
+                type: object
+                description: >
+                  Optional destination basenames keyed by the exact source
+                  item strings from `clipboard.files` /
+                  `clipboard.directories`. Used to paste under a new name,
+                  e.g. duplicating `file.txt` in its own directory as
+                  `file_1.txt`. Values must be plain names without path
+                  separators or `..` components.
+                additionalProperties:
                   type: string
-              destination:
-                type: string
-                description: Destination directory
-              operation:
-                type: string
-                enum: [copy, move]
-                description: Operation type
             required:
-              - items
-              - destination
-              - operation
+              - disk
+              - path
+              - clipboard
     responses:
       '200':
         description: Operation completed
@@ -800,8 +848,29 @@
           application/json:
             schema:
               $ref: '../schemas/SuccessResponse.yaml'
+      '400':
+        description: >
+          Bad request (invalid path or name, unsupported disk or clipboard
+          type, empty clipboard, copy onto itself, or directory pasted into
+          itself)
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/ErrorResponse.yaml'
       '401':
         description: Unauthorized
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/ErrorResponse.yaml'
+      '403':
+        description: User does not have files permission for this server
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/ErrorResponse.yaml'
+      '404':
+        description: Server or node not found
         content:
           application/json:
             schema:

--- a/web/frontend/js/filemanager/lang/en.js
+++ b/web/frontend/js/filemanager/lang/en.js
@@ -261,6 +261,8 @@ const en = {
         copyToClipboard: 'Copied to clipboard!',
         chmodSuccess: 'Permissions changed!',
         chmodError: 'Failed to change permissions!',
+        pasteSameDirectory: 'Items are already in this folder',
+        pasteIntoItself: 'Cannot paste a folder into itself',
     },
     response: {
         noConfig: 'Config not found!',

--- a/web/frontend/js/filemanager/lang/ru.js
+++ b/web/frontend/js/filemanager/lang/ru.js
@@ -261,6 +261,8 @@ const ru = {
         copyToClipboard: 'Скопировано!',
         chmodSuccess: 'Права изменены!',
         chmodError: 'Не удалось изменить права!',
+        pasteSameDirectory: 'Элементы уже находятся в этой папке',
+        pasteIntoItself: 'Нельзя вставить папку саму в себя',
     },
     response: {
         noConfig: 'Конфигурация не найдена!',

--- a/web/frontend/js/filemanager/stores/useFileManagerStore.js
+++ b/web/frontend/js/filemanager/stores/useFileManagerStore.js
@@ -30,10 +30,12 @@ function addRenameSuffix(name, taken, splitExtension = true) {
 }
 
 function normalizeComparePath(p) {
-    return String(p ?? '')
+    const normalized = String(p ?? '')
         .replace(/\\/g, '/')
         .replace(/^\/+/, '')
         .replace(/\/+$/, '')
+
+    return normalized === '.' ? '' : normalized
 }
 
 function basenameOf(p) {
@@ -1013,7 +1015,9 @@ export const useFileManagerStore = defineStore('fm', () => {
                 ...manager.directories.map((d) => d.basename),
                 ...manager.files.map((f) => f.basename),
             ])
-            names = {}
+            // Null prototype: an item literally named "__proto__" must
+            // still become an own enumerable key of the payload map.
+            names = Object.create(null)
             for (const dir of clipboard.value.directories) {
                 if (!inDestDir(dir)) {
                     continue

--- a/web/frontend/js/filemanager/stores/useFileManagerStore.js
+++ b/web/frontend/js/filemanager/stores/useFileManagerStore.js
@@ -9,12 +9,14 @@ import { detectConflicts, joinPath, dirOf } from '../http/upload-conflicts.js'
 import { useSettingsStore } from './useSettingsStore.js'
 import { useMessagesStore } from './useMessagesStore.js'
 import { useModalStore } from './useModalStore.js'
+import { useTranslate } from '../composables/useTranslate.js'
+import { notification } from '@/parts/dialogs.js'
 
 const FILE_CONCURRENCY = 3
 const MKDIR_CONCURRENCY = 5
 
-function addRenameSuffix(name, taken) {
-    const dot = name.lastIndexOf('.')
+function addRenameSuffix(name, taken, splitExtension = true) {
+    const dot = splitExtension ? name.lastIndexOf('.') : -1
     const base = dot > 0 ? name.slice(0, dot) : name
     const ext = dot > 0 ? name.slice(dot) : ''
     let i = 1
@@ -25,6 +27,19 @@ function addRenameSuffix(name, taken) {
     }
 
     return candidate
+}
+
+function normalizeComparePath(p) {
+    return String(p ?? '')
+        .replace(/\\/g, '/')
+        .replace(/^\/+/, '')
+        .replace(/\/+$/, '')
+}
+
+function basenameOf(p) {
+    const normalized = normalizeComparePath(p)
+
+    return normalized.slice(normalized.lastIndexOf('/') + 1)
 }
 
 async function runPool(items, concurrency, worker) {
@@ -963,11 +978,73 @@ export const useFileManagerStore = defineStore('fm', () => {
     }
 
     async function paste() {
-        const response = await POST.paste({
-            disk: selectedDisk.value,
-            path: selectedDirectory.value,
-            clipboard: clipboard.value,
+        const manager = getManager(activeManager.value)
+        const { lang } = useTranslate()
+        const destDir = normalizeComparePath(manager.selectedDirectory)
+        const sameDisk = clipboard.value.disk === manager.selectedDisk
+
+        const pastingIntoItself = sameDisk && clipboard.value.directories.some((dir) => {
+            const src = normalizeComparePath(dir)
+
+            return destDir === src || destDir.startsWith(`${src}/`)
         })
+        if (pastingIntoItself) {
+            notification({ content: lang.value.notifications.pasteIntoItself, type: 'error' })
+
+            return
+        }
+
+        const inDestDir = (itemPath) => sameDisk && dirOf(normalizeComparePath(itemPath)) === destDir
+
+        if (clipboard.value.type === 'cut') {
+            const items = [...clipboard.value.directories, ...clipboard.value.files]
+            if (items.length > 0 && items.every(inDestDir)) {
+                notification({ content: lang.value.notifications.pasteSameDirectory, type: 'info' })
+
+                return
+            }
+        }
+
+        let names = null
+        if (clipboard.value.type === 'copy') {
+            // Hidden entries occupy names too, so collect from the raw
+            // listings rather than the hiddenFiles-filtered getters.
+            const taken = new Set([
+                ...manager.directories.map((d) => d.basename),
+                ...manager.files.map((f) => f.basename),
+            ])
+            names = {}
+            for (const dir of clipboard.value.directories) {
+                if (!inDestDir(dir)) {
+                    continue
+                }
+                const renamed = addRenameSuffix(basenameOf(dir), taken, false)
+                names[dir] = renamed
+                taken.add(renamed)
+            }
+            for (const file of clipboard.value.files) {
+                if (!inDestDir(file)) {
+                    continue
+                }
+                const renamed = addRenameSuffix(basenameOf(file), taken)
+                names[file] = renamed
+                taken.add(renamed)
+            }
+            if (Object.keys(names).length === 0) {
+                names = null
+            }
+        }
+
+        const payload = {
+            disk: manager.selectedDisk,
+            path: manager.selectedDirectory,
+            clipboard: clipboard.value,
+        }
+        if (names) {
+            payload.names = names
+        }
+
+        const response = await POST.paste(payload)
 
         if (response.data.result.status === 'success') {
             refreshManagers()

--- a/web/frontend/tests/e2e/smoke/filemanager-paste.spec.ts
+++ b/web/frontend/tests/e2e/smoke/filemanager-paste.spec.ts
@@ -1,0 +1,170 @@
+import { test, expect, type Page } from '@playwright/test';
+import { loginViaAPI } from '../fixtures/auth';
+import { dismissTopDialog } from '../fixtures/ui';
+
+// Same-directory paste regression coverage (file self-overwrite bug): the
+// file-manager API is fully route-mocked, so no daemon is required — the
+// spec verifies the frontend clipboard logic and the exact paste payloads.
+
+const FILES_TAB = /files|файлы|servers\.files/i;
+
+const TS = 1752800000;
+
+function dirEntry(path: string) {
+  const basename = path.split('/').pop() ?? path;
+  const dirname = path.includes('/') ? path.slice(0, path.lastIndexOf('/')) : '';
+
+  return { path, timestamp: TS, type: 'dir', dirname, basename, mode: 493 };
+}
+
+function fileEntry(path: string) {
+  const basename = path.split('/').pop() ?? path;
+  const dirname = path.includes('/') ? path.slice(0, path.lastIndexOf('/')) : '';
+  const dot = basename.lastIndexOf('.');
+
+  return {
+    path,
+    timestamp: TS,
+    type: 'file',
+    visibility: 'public',
+    size: 64,
+    dirname,
+    basename,
+    extension: dot > 0 ? basename.slice(dot + 1) : undefined,
+    filename: dot > 0 ? basename.slice(0, dot) : basename,
+    mode: 420,
+  };
+}
+
+// Root already contains config_1.txt so the auto-suffix must skip to _2.
+const LISTINGS: Record<string, { directories: object[]; files: object[] }> = {
+  '': {
+    directories: [dirEntry('subdir')],
+    files: [fileEntry('config.txt'), fileEntry('config_1.txt')],
+  },
+  subdir: {
+    directories: [],
+    files: [fileEntry('subdir/other.txt')],
+  },
+};
+
+async function clickTool(page: Page, title: string) {
+  await page.locator(`button.fm-tool-btn[title="${title}"]`).click();
+}
+
+test('same-dir paste auto-renames, same-dir cut is a no-op, folder is not pasted into itself', async ({
+  page,
+  request,
+}) => {
+  test.setTimeout(120_000);
+
+  const token = await loginViaAPI(request);
+  await page.addInitScript((t) => localStorage.setItem('auth_token', t), token);
+
+  const pasteBodies: Array<Record<string, unknown>> = [];
+
+  // Catch-all first: overlapping routes registered later win, so anything
+  // not mocked explicitly still gets a harmless success instead of hitting
+  // the daemon-less backend.
+  await page.route('**/api/file-manager/1/**', (route) =>
+    route.fulfill({ json: { result: { status: 'success', message: '' } } }),
+  );
+  await page.route('**/api/file-manager/1/initialize*', (route) =>
+    route.fulfill({
+      json: {
+        result: { status: 'success', message: null },
+        config: {
+          acl: false,
+          hiddenFiles: true,
+          disks: { server: { driver: 'local' } },
+          lang: 'en',
+          leftDisk: 'server',
+          leftPath: '',
+          windowsConfig: 1,
+        },
+      },
+    }),
+  );
+  await page.route('**/api/file-manager/1/content*', (route) => {
+    const url = new URL(route.request().url());
+    const path = url.searchParams.get('path') ?? '';
+    const listing = LISTINGS[path] ?? { directories: [], files: [] };
+    void route.fulfill({
+      json: { result: { status: 'success', message: null }, ...listing },
+    });
+  });
+  await page.route('**/api/file-manager/1/paste', (route) => {
+    pasteBodies.push(route.request().postDataJSON() as Record<string, unknown>);
+    void route.fulfill({ json: { result: { status: 'success', message: '' } } });
+  });
+
+  await page.goto('/servers/1');
+  await page
+    .locator('.n-tabs-tab', { hasText: FILES_TAB })
+    .click({ timeout: 20_000 });
+
+  const rootFile = page.locator('.fm-row--file', { hasText: 'config.txt' }).first();
+  await expect(rootFile).toBeVisible({ timeout: 20_000 });
+
+  // 1. Copy + paste in the same directory → auto-renamed payload; the
+  //    suffix skips the already-existing config_1.txt.
+  await rootFile.click();
+  await clickTool(page, 'Copy');
+  await dismissTopDialog(page); // "Copied to clipboard!"
+  await clickTool(page, 'Paste');
+  await expect.poll(() => pasteBodies.length).toBe(1);
+  expect(pasteBodies[0].names).toEqual({ 'config.txt': 'config_2.txt' });
+  expect(pasteBodies[0].path).toBeNull();
+  expect((pasteBodies[0].clipboard as { type: string }).type).toBe('copy');
+
+  // 2. Cut + paste in the same directory → no request, info dialog,
+  //    clipboard survives (paste button stays enabled).
+  await rootFile.click();
+  await clickTool(page, 'Cut');
+  await dismissTopDialog(page); // "Cut to clipboard!"
+  await clickTool(page, 'Paste');
+  await expect(page.getByRole('dialog').last()).toContainText(
+    'Items are already in this folder',
+    { timeout: 10_000 },
+  );
+  await dismissTopDialog(page);
+  expect(pasteBodies).toHaveLength(1);
+  await expect(
+    page.locator('button.fm-tool-btn[title="Paste"]'),
+  ).toBeEnabled();
+
+  // 3. Copy a folder, enter it, paste → error dialog, no request.
+  const subdirRow = page.locator('.fm-row--directory', { hasText: 'subdir' });
+  await subdirRow.click();
+  await clickTool(page, 'Copy');
+  await dismissTopDialog(page);
+  await subdirRow.dblclick();
+  await expect(
+    page.locator('.fm-row--file', { hasText: 'other.txt' }),
+  ).toBeVisible({ timeout: 10_000 });
+  await clickTool(page, 'Paste');
+  await expect(page.getByRole('dialog').last()).toContainText(
+    'Cannot paste a folder into itself',
+    { timeout: 10_000 },
+  );
+  await dismissTopDialog(page);
+  expect(pasteBodies).toHaveLength(1);
+
+  // 4. Cross-directory copy stays unchanged: no names in the payload.
+  await page.locator('.fm-row--up').click();
+  await expect(rootFile).toBeVisible({ timeout: 10_000 });
+  await rootFile.click();
+  await clickTool(page, 'Copy');
+  await dismissTopDialog(page);
+  await subdirRow.dblclick();
+  await expect(
+    page.locator('.fm-row--file', { hasText: 'other.txt' }),
+  ).toBeVisible({ timeout: 10_000 });
+  await clickTool(page, 'Paste');
+  await expect.poll(() => pasteBodies.length).toBe(2);
+  expect(pasteBodies[1].path).toBe('subdir');
+  expect(pasteBodies[1].names).toBeUndefined();
+  expect((pasteBodies[1].clipboard as { files: string[] }).files).toEqual([
+    'config.txt',
+  ]);
+});

--- a/web/frontend/tests/e2e/smoke/filemanager-paste.spec.ts
+++ b/web/frontend/tests/e2e/smoke/filemanager-paste.spec.ts
@@ -63,6 +63,42 @@ test('same-dir paste auto-renames, same-dir cut is a no-op, folder is not pasted
 
   const pasteBodies: Array<Record<string, unknown>> = [];
 
+  // The server page API is mocked as well: CI runs without any server row
+  // in the DB (servers cannot be provisioned without an enrolled daemon),
+  // so the spec must not depend on GET /api/servers/1 hitting the backend.
+  await page.route('**/api/servers/1/**', (route) =>
+    route.fulfill({ json: {} }),
+  );
+  await page.route('**/api/servers/1', (route) =>
+    route.fulfill({
+      json: {
+        id: 1,
+        uid: '11111111-1111-1111-1111-111111111111',
+        uuid: '11111111-1111-1111-1111-111111111111',
+        uuid_short: '11111111',
+        enabled: true,
+        installed: 1,
+        blocked: false,
+        name: 'E2E FM Server',
+        game_id: 'cs',
+        ds_id: 1,
+        game_mod_id: 1,
+        server_ip: '127.0.0.1',
+        server_port: 27015,
+        online: false,
+        game: { code: 'cs', name: 'Counter-Strike' },
+      },
+    }),
+  );
+  await page.route('**/api/servers/1/abilities', (route) =>
+    route.fulfill({
+      json: {
+        'game-server-common': true,
+        'game-server-files': true,
+      },
+    }),
+  );
+
   // Catch-all first: overlapping routes registered later win, so anything
   // not mocked explicitly still gets a harmless success instead of hitting
   // the daemon-less backend.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Same-folder copy now auto-generates unique destination names to prevent collisions (including renamed/hidden items).
  - Paste now supports per-item basename overrides via an optional `names` mapping.
  - Improved protections against recursive “paste folder into itself” and related directory subtree cases.
  - Cut to the current folder is treated as a no-op.

- **Bug Fixes**
  - More consistent destination path handling and validation for files vs folders.
  - Paste/cut batches now fail cleanly for invalid rename inputs without partial application.

- **Documentation**
  - Expanded the `/paste` API contract and clarified copy vs move semantics and error cases.

- **Tests**
  - Added/expanded backend and Playwright smoke coverage for paste/copy/cut edge scenarios.
  - Added new UI notifications for same-folder and self-folder paste errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->