### PR TITLE
Plugin updates. Checking game and engine on game server tabs

### DIFF
--- a/web/frontend/js/plugins/README.md
+++ b/web/frontend/js/plugins/README.md
@@ -52,6 +52,28 @@ Supports `hasServerPermissions` permission check:
 
 The tab is only shown if the user has all specified permissions for the current server.
 
+#### Game Matching
+
+Supports `checkGame` to show the tab only for servers running specific games.
+The tab is shown when the server's game matches at least one listed engine
+(case-insensitive) or game code. Both conditions can be combined; while the
+server data is still loading, the tab stays hidden.
+
+```javascript
+{
+  component: MyTabComponent,
+  label: 'My Tab',
+  icon: 'puzzle-piece',
+  checkGame: {
+    engines: ['GoldSource'],       // matches game.engine
+    codes: ['cstrike', 'valve']    // matches game.code
+  }
+}
+```
+
+`checkGame` and `checkPermission` are independent: when both are set, the tab
+is shown only if both checks pass.
+
 #### Usage Example
 
 ```javascript

--- a/web/frontend/js/plugins/loader.js
+++ b/web/frontend/js/plugins/loader.js
@@ -152,6 +152,7 @@ async function registerPluginDefinition(pluginDef, store) {
                     icon: slotComp.icon,
                     name: slotComp.name,
                     checkPermission: slotComp.checkPermission,
+                    checkGame: slotComp.checkGame,
                 })
             }
         }

--- a/web/frontend/js/store/plugins/index.js
+++ b/web/frontend/js/store/plugins/index.js
@@ -87,6 +87,7 @@ export const usePluginsStore = defineStore('plugins', () => {
             icon: options.icon || null,
             name: options.name || '',
             checkPermission: options.checkPermission || null,
+            checkGame: options.checkGame || null,
         })
 
         slots[slotName].sort((a, b) => a.order - b.order)

--- a/web/frontend/js/views/ServerIdView.vue
+++ b/web/frontend/js/views/ServerIdView.vue
@@ -413,6 +413,9 @@ const isAdmin = computed(() => {
 const pluginTabs = computed(() => {
   const allTabs = pluginsStore.getSlotComponents('server-tabs')
   return allTabs.filter(tab => {
+    if (!matchesTabGame(tab.checkGame)) {
+      return false
+    }
     if (!tab.checkPermission) return true
     if (tab.checkPermission.type === 'hasServerPermissions') {
       return tab.checkPermission.permissions.every(
@@ -422,6 +425,20 @@ const pluginTabs = computed(() => {
     return true
   })
 })
+
+function matchesTabGame(checkGame) {
+  if (!checkGame) return true
+  const game = server.value?.game
+  if (!game) return false
+  const engines = checkGame.engines ?? []
+  const codes = checkGame.codes ?? []
+  if (engines.length === 0 && codes.length === 0) return true
+  const engineMatches = engines.some(
+      engine => String(engine).toLowerCase() === String(game.engine ?? '').toLowerCase()
+  )
+  const codeMatches = codes.includes(game.code)
+  return engineMatches || codeMatches
+}
 
 function hashToTabName(hash) {
   if (!hash || hash === '#' || hash === '#control') {

--- a/web/plugin-sdk/package.json
+++ b/web/plugin-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gameap/plugin-sdk",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "SDK for developing GameAP frontend plugins",
   "type": "module",
   "main": "./dist/index.js",

--- a/web/plugin-sdk/src/types.ts
+++ b/web/plugin-sdk/src/types.ts
@@ -107,6 +107,18 @@ export interface HasServerPermissionsCheck {
 export type PermissionCheck = HasServerPermissionsCheck;
 
 /**
+ * Game match condition for slot components.
+ * Supported by the server-tabs slot: the tab is shown only when the
+ * current server's game matches at least one of the listed values.
+ */
+export interface GameCheck {
+    /** Game engines to match (case-insensitive), e.g. ['GoldSource'] */
+    engines?: string[];
+    /** Game codes to match, e.g. ['cstrike', 'valve'] */
+    codes?: string[];
+}
+
+/**
  * Plugin slot component definition.
  */
 export interface PluginSlotComponent {
@@ -124,6 +136,8 @@ export interface PluginSlotComponent {
     props?: Record<string, unknown>;
     /** Permission check - each slot recipient checks types it understands */
     checkPermission?: PermissionCheck;
+    /** Game match condition - each slot recipient checks it if supported */
+    checkGame?: GameCheck;
 }
 
 /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plugin server tabs can now be shown only for matching games, based on engine or game code.
  * Game matching is case-insensitive and supports multiple engines or codes.
  * Game matching works independently alongside permission checks.
  * Plugin developers can configure game-based tab visibility through the updated SDK.

* **Documentation**
  * Added documentation explaining game-matching configuration and loading behavior.

* **Chores**
  * Updated the plugin SDK version to 0.3.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->