### PR TITLE
Fix large message bug in goldsource rcon

### DIFF
--- a/pkg/quercon/rcon/goldsource.go
+++ b/pkg/quercon/rcon/goldsource.go
@@ -55,6 +55,9 @@ func (g *GoldSource) Open(ctx context.Context) error {
 	g.connection = conn
 
 	if err := g.getChallengeNumber(); err != nil {
+		_ = conn.Close()
+		g.connection = nil
+
 		return err
 	}
 

--- a/pkg/quercon/rcon/goldsource.go
+++ b/pkg/quercon/rcon/goldsource.go
@@ -1,7 +1,6 @@
 package rcon
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"net"
@@ -15,6 +14,10 @@ const (
 	header               = "\xff\xff\xff\xff"
 	defaultBufferSize    = 1024
 	maxSymbolsPerCommand = 256
+	// maxResponseSize is the read buffer for a single UDP datagram. GoldSource can send RCON
+	// replies up to the network MTU, so this is sized to the maximum UDP payload to avoid
+	// truncating (and silently dropping) the tail of a datagram.
+	maxResponseSize = 65535
 )
 
 var (
@@ -85,6 +88,10 @@ func (g *GoldSource) Execute(_ context.Context, command string) (string, error) 
 
 		cmdPartResult, err := g.writeAndReadSocket(cmd)
 		if err != nil {
+			if !firstCommand && isTimeoutError(err) {
+				break
+			}
+
 			return "", err
 		}
 
@@ -106,7 +113,7 @@ func (g *GoldSource) getChallengeNumber() error {
 		return err
 	}
 
-	parts := strings.Split(string(response), " ")
+	parts := strings.Fields(string(response))
 	if len(parts) < 3 {
 		return ErrInvalidChallengeResponse
 	}
@@ -121,10 +128,13 @@ func (g *GoldSource) writeAndReadSocket(command string) ([]byte, error) {
 		return nil, err
 	}
 
-	reader := bufio.NewReader(g.connection)
-	buffer := make([]byte, defaultBufferSize)
+	if g.timeout > 0 {
+		_ = g.connection.SetReadDeadline(time.Now().Add(g.timeout))
+	}
 
-	n, err := reader.Read(buffer)
+	buffer := make([]byte, maxResponseSize)
+
+	n, err := g.connection.Read(buffer)
 	if err != nil {
 		return nil, err
 	}
@@ -133,7 +143,11 @@ func (g *GoldSource) writeAndReadSocket(command string) ([]byte, error) {
 		return nil, nil
 	}
 
-	return bytes.TrimSpace(
-		bytes.Trim(buffer[5:n], "\x00"),
-	), nil
+	return bytes.Trim(buffer[5:n], "\x00"), nil
+}
+
+func isTimeoutError(err error) bool {
+	var netErr net.Error
+
+	return errors.As(err, &netErr) && netErr.Timeout()
 }

--- a/pkg/quercon/rcon/goldsource_test.go
+++ b/pkg/quercon/rcon/goldsource_test.go
@@ -91,6 +91,7 @@ func TestGoldSource_getChallengeNumber_RejectsMalformedReplies(t *testing.T) {
 
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tt.wantError)
+			assert.Nil(t, g.connection, "a failed Open must release the dialed connection")
 		})
 	}
 }
@@ -338,11 +339,13 @@ func TestGoldSource_Open_TimesOutOnSilentServer(t *testing.T) {
 		return nil // never answer the challenge request
 	})
 
+	const timeout = 300 * time.Millisecond
+
 	g, err := NewGoldSource(Config{
 		Address:  srv.addr,
 		Password: "pw",
 		Protocol: ProtocolGoldSrc,
-		Timeout:  300 * time.Millisecond,
+		Timeout:  timeout,
 	})
 	require.NoError(t, err)
 
@@ -351,6 +354,6 @@ func TestGoldSource_Open_TimesOutOnSilentServer(t *testing.T) {
 	defer func() { _ = g.Close() }()
 
 	require.Error(t, err, "a silent server must not hang Open forever")
-	assert.Less(t, time.Since(start), 5*time.Second,
-		"Open must return around the configured Timeout, not block indefinitely")
+	assert.Less(t, time.Since(start), timeout+time.Second,
+		"Open must return around the configured Timeout, not block for seconds")
 }

--- a/pkg/quercon/rcon/goldsource_test.go
+++ b/pkg/quercon/rcon/goldsource_test.go
@@ -229,8 +229,128 @@ func TestGoldSource_Close_NilConnection(t *testing.T) {
 	assert.NoError(t, g.Close(), "Close on a never-opened goldsource must be a no-op")
 }
 
-// NOTE: There is no test for "Open against a silent UDP server" because GoldSource only applies
-// Config.Timeout to the dial step (net.Dialer.Timeout) and never calls SetReadDeadline on the
-// socket. A silent server therefore blocks Open forever — this is a property of the production
-// code, not of the test, and cannot be exercised without changing GoldSource.Open. Keeping this
-// note so the gap is documented.
+func TestGoldSource_Execute_LargeDatagramNotTruncated(t *testing.T) {
+	const challenge = "777"
+	// Non-whitespace, position-identifiable content larger than the old 1024-byte read buffer.
+	// Before the fix this datagram was chopped to 1019 bytes and its tail was silently dropped.
+	longBody := strings.Repeat("0123456789", 130) // 1300 bytes
+	const tail = "END"
+
+	srv := newScriptedUDPServer(t, func(_ []byte, idx int) []byte {
+		switch idx {
+		case 0:
+			return []byte(header + "\x00challenge rcon " + challenge + "\n")
+		case 1:
+			return []byte(header + "\x00" + longBody)
+		case 2:
+			return []byte(header + "\x00" + tail)
+		}
+
+		return nil
+	})
+
+	g, err := NewGoldSource(Config{
+		Address:  srv.addr,
+		Password: "pw",
+		Protocol: ProtocolGoldSrc,
+		Timeout:  2 * time.Second,
+	})
+	require.NoError(t, err)
+	require.NoError(t, g.Open(context.Background()))
+	defer func() { _ = g.Close() }()
+
+	got, err := g.Execute(context.Background(), "amxx plugins")
+	require.NoError(t, err)
+	assert.Equal(t, longBody+tail, got,
+		"a datagram larger than the old 1024-byte buffer must be returned in full and joined with the next part")
+}
+
+func TestGoldSource_Execute_PreservesBoundaryWhitespace(t *testing.T) {
+	const challenge = "555"
+	// First part exceeds maxSymbolsPerCommand so a continuation is fetched, and it ends with a
+	// space that lands exactly on the datagram boundary. The old per-chunk TrimSpace ate it.
+	firstPart := strings.Repeat("a", maxSymbolsPerCommand) + " foo "
+	const secondPart = "bar"
+
+	srv := newScriptedUDPServer(t, func(_ []byte, idx int) []byte {
+		switch idx {
+		case 0:
+			return []byte(header + "\x00challenge rcon " + challenge + "\n")
+		case 1:
+			return []byte(header + "\x00" + firstPart)
+		case 2:
+			return []byte(header + "\x00" + secondPart)
+		}
+
+		return nil
+	})
+
+	g, err := NewGoldSource(Config{
+		Address:  srv.addr,
+		Password: "pw",
+		Protocol: ProtocolGoldSrc,
+		Timeout:  2 * time.Second,
+	})
+	require.NoError(t, err)
+	require.NoError(t, g.Open(context.Background()))
+	defer func() { _ = g.Close() }()
+
+	got, err := g.Execute(context.Background(), "status")
+	require.NoError(t, err)
+	assert.Contains(t, got, "foo bar",
+		"whitespace on a datagram boundary must survive reassembly")
+}
+
+func TestGoldSource_Execute_ContinuationTimeoutTerminatesLoop(t *testing.T) {
+	const challenge = "321"
+	firstPart := strings.Repeat("Z", maxSymbolsPerCommand+10) // forces a continuation read
+
+	srv := newScriptedUDPServer(t, func(_ []byte, idx int) []byte {
+		switch idx {
+		case 0:
+			return []byte(header + "\x00challenge rcon " + challenge + "\n")
+		case 1:
+			return []byte(header + "\x00" + firstPart)
+		}
+		// The continuation request (idx 2) gets no reply: the loop must time out and return what
+		// it already has instead of erroring or blocking forever.
+		return nil
+	})
+
+	g, err := NewGoldSource(Config{
+		Address:  srv.addr,
+		Password: "pw",
+		Protocol: ProtocolGoldSrc,
+		Timeout:  300 * time.Millisecond,
+	})
+	require.NoError(t, err)
+	require.NoError(t, g.Open(context.Background()))
+	defer func() { _ = g.Close() }()
+
+	got, err := g.Execute(context.Background(), "status")
+	require.NoError(t, err,
+		"a continuation-read timeout must be treated as end-of-response, not an error")
+	assert.Equal(t, firstPart, got, "the already-received part must be returned intact")
+}
+
+func TestGoldSource_Open_TimesOutOnSilentServer(t *testing.T) {
+	srv := newScriptedUDPServer(t, func(_ []byte, _ int) []byte {
+		return nil // never answer the challenge request
+	})
+
+	g, err := NewGoldSource(Config{
+		Address:  srv.addr,
+		Password: "pw",
+		Protocol: ProtocolGoldSrc,
+		Timeout:  300 * time.Millisecond,
+	})
+	require.NoError(t, err)
+
+	start := time.Now()
+	err = g.Open(context.Background())
+	defer func() { _ = g.Close() }()
+
+	require.Error(t, err, "a silent server must not hang Open forever")
+	assert.Less(t, time.Since(start), 5*time.Second,
+		"Open must return around the configured Timeout, not block indefinitely")
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of large UDP responses so returned data is no longer truncated.
  * Preserved whitespace correctly when responses span multiple packets and datagram boundaries.
  * Improved timeout handling for incomplete multi-part responses so they stop reading instead of returning a timeout error.
  * Hardened parsing of server challenge responses to better tolerate varied whitespace.
  * Ensured failed connection setup to an unresponsive server doesn’t leave an active UDP connection behind.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->