### PR TITLE
goldsource rcon fix

### DIFF
--- a/pkg/quercon/rcon/goldsource.go
+++ b/pkg/quercon/rcon/goldsource.go
@@ -20,6 +20,11 @@ const (
 	// GoldSource sends every part of a large RCON reply back-to-back right after the command,
 	// so a short idle gap means the response is complete.
 	responseIdleTimeout = 500 * time.Millisecond
+	// maxReassembledResponseSize caps the total size of a reassembled multi-packet response.
+	// Without it a server streaming datagrams faster than the idle timeout would grow the
+	// reassembly buffer without bound. Sized well above real-world replies (a full cvarlist
+	// dump is tens of KiB).
+	maxReassembledResponseSize = 1 << 20 // 1 MiB
 )
 
 var (
@@ -111,6 +116,12 @@ func (g *GoldSource) Execute(_ context.Context, command string) (string, error) 
 		}
 
 		buffer.Write(part)
+
+		// Stop once the accumulated response exceeds the cap; any datagrams still
+		// queued afterwards are drained before the next command.
+		if buffer.Len() > maxReassembledResponseSize {
+			break
+		}
 	}
 
 	return strings.TrimSpace(buffer.String()), nil

--- a/pkg/quercon/rcon/goldsource.go
+++ b/pkg/quercon/rcon/goldsource.go
@@ -11,13 +11,15 @@ import (
 )
 
 const (
-	header               = "\xff\xff\xff\xff"
-	defaultBufferSize    = 1024
-	maxSymbolsPerCommand = 256
+	header = "\xff\xff\xff\xff"
 	// maxResponseSize is the read buffer for a single UDP datagram. GoldSource can send RCON
 	// replies up to the network MTU, so this is sized to the maximum UDP payload to avoid
 	// truncating (and silently dropping) the tail of a datagram.
 	maxResponseSize = 65535
+	// responseIdleTimeout bounds the wait for follow-up datagrams of a multi-packet response.
+	// GoldSource sends every part of a large RCON reply back-to-back right after the command,
+	// so a short idle gap means the response is complete.
+	responseIdleTimeout = 500 * time.Millisecond
 )
 
 var (
@@ -76,35 +78,39 @@ func (g *GoldSource) Close() error {
 }
 
 func (g *GoldSource) Execute(_ context.Context, command string) (string, error) {
-	firstCommand := true
+	// Drop late or unsolicited datagrams left over from previous commands so the first
+	// read below belongs to this command's response (matters for reused pooled connections).
+	g.drainStaleDatagrams()
+
+	cmd := header + "rcon " + g.challengeNumber + " \"" + g.password + "\" " + command
+
+	if _, err := g.connection.Write([]byte(cmd)); err != nil {
+		return "", err
+	}
 
 	buffer := bytes.Buffer{}
-	buffer.Grow(defaultBufferSize)
 
+	// The first datagram of the response gets the full configured timeout.
+	part, err := g.readDatagram(g.timeout)
+	if err != nil {
+		return "", err
+	}
+
+	buffer.Write(part)
+
+	// A large response arrives as several back-to-back datagrams; read until the socket
+	// goes idle instead of polling the server with extra "continuation" rcon requests.
 	for {
-		var cmd string
-		if firstCommand {
-			cmd = header + "rcon " + g.challengeNumber + " \"" + g.password + "\" " + command
-		} else {
-			cmd = header + "rcon " + g.challengeNumber + " \"" + g.password + "\""
-		}
-
-		cmdPartResult, err := g.writeAndReadSocket(cmd)
+		part, err = g.readDatagram(responseIdleTimeout)
 		if err != nil {
-			if !firstCommand && isTimeoutError(err) {
+			if isTimeoutError(err) {
 				break
 			}
 
 			return "", err
 		}
 
-		buffer.Write(cmdPartResult)
-
-		if len(cmdPartResult) < maxSymbolsPerCommand {
-			break
-		}
-
-		firstCommand = false
+		buffer.Write(part)
 	}
 
 	return strings.TrimSpace(buffer.String()), nil
@@ -131,8 +137,15 @@ func (g *GoldSource) writeAndReadSocket(command string) ([]byte, error) {
 		return nil, err
 	}
 
-	if g.timeout > 0 {
-		_ = g.connection.SetReadDeadline(time.Now().Add(g.timeout))
+	return g.readDatagram(g.timeout)
+}
+
+// readDatagram reads a single UDP datagram and returns its body with the 5-byte GoldSource
+// prefix (4-byte header plus the 'l' print type) and trailing NULs stripped. Datagrams that
+// do not carry the GoldSource header, or carry no body at all, yield nil.
+func (g *GoldSource) readDatagram(timeout time.Duration) ([]byte, error) {
+	if timeout > 0 {
+		_ = g.connection.SetReadDeadline(time.Now().Add(timeout))
 	}
 
 	buffer := make([]byte, maxResponseSize)
@@ -142,11 +155,25 @@ func (g *GoldSource) writeAndReadSocket(command string) ([]byte, error) {
 		return nil, err
 	}
 
-	if n < 5 {
-		return nil, nil
+	if !bytes.HasPrefix(buffer[:n], []byte(header)) || n < 5 {
+		return nil, nil //nolint:nilnil // "no usable body" is not an error here
 	}
 
 	return bytes.Trim(buffer[5:n], "\x00"), nil
+}
+
+// drainStaleDatagrams discards datagrams already sitting in the socket receive buffer
+// (late replies to previous commands) so the next read starts from a clean slate.
+func (g *GoldSource) drainStaleDatagrams() {
+	buffer := make([]byte, maxResponseSize)
+
+	for {
+		_ = g.connection.SetReadDeadline(time.Now())
+
+		if _, err := g.connection.Read(buffer); err != nil {
+			return
+		}
+	}
 }
 
 func isTimeoutError(err error) bool {

--- a/pkg/quercon/rcon/goldsource_test.go
+++ b/pkg/quercon/rcon/goldsource_test.go
@@ -461,3 +461,48 @@ func TestGoldSource_Open_TimesOutOnSilentServer(t *testing.T) {
 	assert.Less(t, time.Since(start), timeout+time.Second,
 		"Open must return around the configured Timeout, not block for seconds")
 }
+
+func TestGoldSource_Execute_CapsReassembledResponse(t *testing.T) {
+	const challenge = "888"
+
+	// Enough back-to-back datagrams to exceed maxReassembledResponseSize with no idle gap.
+	datagrams := make([][]byte, 0, maxReassembledResponseSize/4096+2)
+	for range maxReassembledResponseSize/4096 + 2 {
+		datagrams = append(datagrams, []byte(header+"\x00"+strings.Repeat("D", 4096)))
+	}
+
+	srv := newScriptedUDPServer(t, func(_ []byte, idx int) [][]byte {
+		switch idx {
+		case 0:
+			return [][]byte{[]byte(header + "\x00challenge rcon " + challenge + "\n")}
+		case 1:
+			return datagrams
+		}
+
+		return nil
+	})
+
+	g, err := NewGoldSource(Config{
+		Address:  srv.addr,
+		Password: "pw",
+		Protocol: ProtocolGoldSrc,
+		Timeout:  2 * time.Second,
+	})
+	require.NoError(t, err)
+	require.NoError(t, g.Open(context.Background()))
+	defer func() { _ = g.Close() }()
+
+	// The default OS UDP receive buffer (~768 KiB on macOS) is smaller than the cap;
+	// enlarge it so the whole burst fits and the test exercises the client-side cap
+	// instead of kernel-level datagram drops.
+	udpConn, ok := g.connection.(*net.UDPConn)
+	require.True(t, ok, "goldsource connection must be a *net.UDPConn")
+	require.NoError(t, udpConn.SetReadBuffer(4<<20))
+
+	got, err := g.Execute(context.Background(), "cvarlist")
+	require.NoError(t, err, "hitting the size cap must end the response normally, not error")
+	assert.Greater(t, len(got), maxReassembledResponseSize,
+		"the accumulated response must be returned once the cap is exceeded")
+	assert.Less(t, len(got), maxReassembledResponseSize+maxResponseSize,
+		"the response must stop growing right after the cap is exceeded")
+}

--- a/pkg/quercon/rcon/goldsource_test.go
+++ b/pkg/quercon/rcon/goldsource_test.go
@@ -2,7 +2,9 @@ package rcon
 
 import (
 	"context"
+	"net"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -11,11 +13,11 @@ import (
 )
 
 func TestGoldSource_Open_AcceptsValidChallengeReply(t *testing.T) {
-	srv := newScriptedUDPServer(t, func(req []byte, _ int) []byte {
+	srv := newScriptedUDPServer(t, func(req []byte, _ int) [][]byte {
 		assert.Equal(t, header+"challenge rcon", string(req),
 			"first datagram must be the GoldSource challenge request")
 
-		return []byte(header + "\x00challenge rcon 1234567\n")
+		return [][]byte{[]byte(header + "\x00challenge rcon 1234567\n")}
 	})
 
 	g, err := NewGoldSource(Config{
@@ -74,8 +76,8 @@ func TestGoldSource_getChallengeNumber_RejectsMalformedReplies(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			srv := newScriptedUDPServer(t, func(_ []byte, _ int) []byte {
-				return tt.reply
+			srv := newScriptedUDPServer(t, func(_ []byte, _ int) [][]byte {
+				return [][]byte{tt.reply}
 			})
 
 			g, err := NewGoldSource(Config{
@@ -97,10 +99,9 @@ func TestGoldSource_getChallengeNumber_RejectsMalformedReplies(t *testing.T) {
 }
 
 func TestGoldSource_getChallengeNumber_ShortReply_LeavesChallengeEmpty(t *testing.T) {
-	srv := newScriptedUDPServer(t, func(_ []byte, _ int) []byte {
-		// 5 bytes total — writeAndReadSocket returns nil (n < 5 after the 5 leading bytes are consumed
-		// is the documented "no body" case). Splitting "" by " " yields [""] (one part) → invalid challenge.
-		return []byte("\xff\xff\xff\xff")
+	srv := newScriptedUDPServer(t, func(_ []byte, _ int) [][]byte {
+		// 4 bytes total — a bare header with no challenge body.
+		return [][]byte{[]byte("\xff\xff\xff\xff")}
 	})
 
 	g, err := NewGoldSource(Config{
@@ -122,16 +123,20 @@ func TestGoldSource_Execute_SinglePacketResponse(t *testing.T) {
 	const password = "topsecret"
 	const challenge = "424242"
 
-	srv := newScriptedUDPServer(t, func(req []byte, idx int) []byte {
+	var requests atomic.Int32
+
+	srv := newScriptedUDPServer(t, func(req []byte, idx int) [][]byte {
+		requests.Add(1)
+
 		switch idx {
 		case 0:
-			return []byte(header + "\x00challenge rcon " + challenge + "\n")
+			return [][]byte{[]byte(header + "\x00challenge rcon " + challenge + "\n")}
 		case 1:
 			expectedPrefix := header + "rcon " + challenge + " \"" + password + "\" status"
 			assert.Equal(t, expectedPrefix, string(req),
 				"command datagram must include challenge, quoted password and command")
 
-			return []byte(header + "\x00short response\n")
+			return [][]byte{[]byte(header + "\x00short response\n")}
 		}
 
 		return nil
@@ -151,29 +156,33 @@ func TestGoldSource_Execute_SinglePacketResponse(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "short response", got,
 		"single-packet body must be returned trimmed of trailing whitespace and nulls")
+	assert.EqualValues(t, 2, requests.Load(),
+		"a single-packet response must be fetched with exactly one rcon request")
 }
 
-func TestGoldSource_Execute_MultiPartLoopTerminatesOnShortReply(t *testing.T) {
+func TestGoldSource_Execute_MultiPacketResponseReassembled(t *testing.T) {
 	const challenge = "999"
-	longBody := strings.Repeat("A", maxSymbolsPerCommand+50) // forces a follow-up request
+	part1 := strings.Repeat("A", 300)
+	const part2 = "tail\n"
 
-	srv := newScriptedUDPServer(t, func(req []byte, idx int) []byte {
+	var requests atomic.Int32
+
+	srv := newScriptedUDPServer(t, func(req []byte, idx int) [][]byte {
+		requests.Add(1)
+
 		switch idx {
 		case 0:
-			return []byte(header + "\x00challenge rcon " + challenge + "\n")
+			return [][]byte{[]byte(header + "\x00challenge rcon " + challenge + "\n")}
 		case 1:
 			assert.Contains(t, string(req), "status",
-				"first command datagram must carry the user-supplied command")
+				"the command datagram must carry the user-supplied command")
 
-			return []byte(header + "\x00" + longBody)
-		case 2:
-			// Continuation request must omit the command but keep challenge + password.
-			assert.NotContains(t, string(req), "status",
-				"continuation datagram must drop the original command")
-			assert.Contains(t, string(req), "rcon "+challenge,
-				"continuation datagram must keep the challenge")
-
-			return []byte(header + "\x00tail\n")
+			// GoldSource sends a large reply as several back-to-back datagrams to a
+			// single request; no follow-up request is needed to receive them all.
+			return [][]byte{
+				[]byte(header + "\x00" + part1),
+				[]byte(header + "\x00" + part2),
+			}
 		}
 
 		return nil
@@ -192,15 +201,100 @@ func TestGoldSource_Execute_MultiPartLoopTerminatesOnShortReply(t *testing.T) {
 	got, err := g.Execute(context.Background(), "status")
 	require.NoError(t, err)
 
-	assert.True(t, strings.HasPrefix(got, longBody),
-		"aggregate response must begin with the first part returned by the server")
-	assert.True(t, strings.HasSuffix(got, "tail"),
-		"aggregate response must end with the final short reply")
+	assert.Equal(t, part1+"tail", got,
+		"all datagrams of the response must be reassembled in order")
+	assert.EqualValues(t, 2, requests.Load(),
+		"the whole multi-packet response must be fetched with a single rcon request")
+}
+
+func TestGoldSource_Execute_ShortIntermediatePacketDoesNotEndResponse(t *testing.T) {
+	const challenge = "111"
+	// A short datagram in the MIDDLE of a response must not terminate reassembly:
+	// only an idle gap marks the end of the response. UDP may also deliver datagrams
+	// out of order, so packet size is not a reliable end-of-response signal.
+	const part1 = "abc"
+	part2 := strings.Repeat("B", 300)
+
+	srv := newScriptedUDPServer(t, func(_ []byte, idx int) [][]byte {
+		switch idx {
+		case 0:
+			return [][]byte{[]byte(header + "\x00challenge rcon " + challenge + "\n")}
+		case 1:
+			return [][]byte{
+				[]byte(header + "\x00" + part1),
+				[]byte(header + "\x00" + part2),
+			}
+		}
+
+		return nil
+	})
+
+	g, err := NewGoldSource(Config{
+		Address:  srv.addr,
+		Password: "pw",
+		Protocol: ProtocolGoldSrc,
+		Timeout:  2 * time.Second,
+	})
+	require.NoError(t, err)
+	require.NoError(t, g.Open(context.Background()))
+	defer func() { _ = g.Close() }()
+
+	got, err := g.Execute(context.Background(), "status")
+	require.NoError(t, err)
+	assert.Equal(t, part1+part2, got,
+		"a short intermediate datagram must not truncate the rest of the response")
+}
+
+func TestGoldSource_Execute_LateDatagramDoesNotPoisonNextCommand(t *testing.T) {
+	const challenge = "222"
+
+	srv := newScriptedUDPServer(t, func(_ []byte, idx int) [][]byte {
+		switch idx {
+		case 0:
+			return [][]byte{[]byte(header + "\x00challenge rcon " + challenge + "\n")}
+		case 1:
+			return [][]byte{[]byte(header + "\x00first")}
+		case 2:
+			return [][]byte{[]byte(header + "\x00second")}
+		}
+
+		return nil
+	})
+
+	g, err := NewGoldSource(Config{
+		Address:  srv.addr,
+		Password: "pw",
+		Protocol: ProtocolGoldSrc,
+		Timeout:  2 * time.Second,
+	})
+	require.NoError(t, err)
+	require.NoError(t, g.Open(context.Background()))
+	defer func() { _ = g.Close() }()
+
+	got, err := g.Execute(context.Background(), "first command")
+	require.NoError(t, err)
+	require.Equal(t, "first", got)
+
+	// A stray datagram lands in the receive buffer between commands (a late reply to the
+	// previous command on a reused connection). The next Execute must drain it instead of
+	// mistaking it for its own response.
+	injector, err := net.Dial("udp", g.connection.LocalAddr().String())
+	require.NoError(t, err)
+	_, err = injector.Write([]byte(header + "lSTALE"))
+	require.NoError(t, err)
+	require.NoError(t, injector.Close())
+
+	time.Sleep(50 * time.Millisecond) // let the stray datagram reach the socket buffer
+
+	got, err = g.Execute(context.Background(), "second command")
+	require.NoError(t, err)
+	assert.Equal(t, "second", got,
+		"a stale datagram left over between commands must be drained, not returned")
 }
 
 func TestGoldSource_Execute_PropagatesWriteErrorWhenSocketClosed(t *testing.T) {
-	srv := newScriptedUDPServer(t, func(_ []byte, _ int) []byte {
-		return []byte(header + "\x00challenge rcon 5\n")
+	srv := newScriptedUDPServer(t, func(_ []byte, _ int) [][]byte {
+		return [][]byte{[]byte(header + "\x00challenge rcon 5\n")}
 	})
 
 	g, err := NewGoldSource(Config{
@@ -237,14 +331,15 @@ func TestGoldSource_Execute_LargeDatagramNotTruncated(t *testing.T) {
 	longBody := strings.Repeat("0123456789", 130) // 1300 bytes
 	const tail = "END"
 
-	srv := newScriptedUDPServer(t, func(_ []byte, idx int) []byte {
+	srv := newScriptedUDPServer(t, func(_ []byte, idx int) [][]byte {
 		switch idx {
 		case 0:
-			return []byte(header + "\x00challenge rcon " + challenge + "\n")
+			return [][]byte{[]byte(header + "\x00challenge rcon " + challenge + "\n")}
 		case 1:
-			return []byte(header + "\x00" + longBody)
-		case 2:
-			return []byte(header + "\x00" + tail)
+			return [][]byte{
+				[]byte(header + "\x00" + longBody),
+				[]byte(header + "\x00" + tail),
+			}
 		}
 
 		return nil
@@ -268,19 +363,20 @@ func TestGoldSource_Execute_LargeDatagramNotTruncated(t *testing.T) {
 
 func TestGoldSource_Execute_PreservesBoundaryWhitespace(t *testing.T) {
 	const challenge = "555"
-	// First part exceeds maxSymbolsPerCommand so a continuation is fetched, and it ends with a
-	// space that lands exactly on the datagram boundary. The old per-chunk TrimSpace ate it.
-	firstPart := strings.Repeat("a", maxSymbolsPerCommand) + " foo "
+	// The first datagram ends with a space that lands exactly on the datagram boundary.
+	// Trimming must happen once at the very end, not per chunk.
+	const firstPart = "foo "
 	const secondPart = "bar"
 
-	srv := newScriptedUDPServer(t, func(_ []byte, idx int) []byte {
+	srv := newScriptedUDPServer(t, func(_ []byte, idx int) [][]byte {
 		switch idx {
 		case 0:
-			return []byte(header + "\x00challenge rcon " + challenge + "\n")
+			return [][]byte{[]byte(header + "\x00challenge rcon " + challenge + "\n")}
 		case 1:
-			return []byte(header + "\x00" + firstPart)
-		case 2:
-			return []byte(header + "\x00" + secondPart)
+			return [][]byte{
+				[]byte(header + "\x00" + firstPart),
+				[]byte(header + "\x00" + secondPart),
+			}
 		}
 
 		return nil
@@ -298,23 +394,24 @@ func TestGoldSource_Execute_PreservesBoundaryWhitespace(t *testing.T) {
 
 	got, err := g.Execute(context.Background(), "status")
 	require.NoError(t, err)
-	assert.Contains(t, got, "foo bar",
+	assert.Equal(t, "foo bar", got,
 		"whitespace on a datagram boundary must survive reassembly")
 }
 
-func TestGoldSource_Execute_ContinuationTimeoutTerminatesLoop(t *testing.T) {
+func TestGoldSource_Execute_IdleTimeoutTerminatesResponse(t *testing.T) {
 	const challenge = "321"
-	firstPart := strings.Repeat("Z", maxSymbolsPerCommand+10) // forces a continuation read
+	const part = "partial response"
 
-	srv := newScriptedUDPServer(t, func(_ []byte, idx int) []byte {
+	srv := newScriptedUDPServer(t, func(_ []byte, idx int) [][]byte {
 		switch idx {
 		case 0:
-			return []byte(header + "\x00challenge rcon " + challenge + "\n")
+			return [][]byte{[]byte(header + "\x00challenge rcon " + challenge + "\n")}
 		case 1:
-			return []byte(header + "\x00" + firstPart)
+			// No further datagrams follow: the read loop must stop on the idle timeout
+			// and return what it already has instead of erroring or blocking forever.
+			return [][]byte{[]byte(header + "\x00" + part)}
 		}
-		// The continuation request (idx 2) gets no reply: the loop must time out and return what
-		// it already has instead of erroring or blocking forever.
+
 		return nil
 	})
 
@@ -322,20 +419,27 @@ func TestGoldSource_Execute_ContinuationTimeoutTerminatesLoop(t *testing.T) {
 		Address:  srv.addr,
 		Password: "pw",
 		Protocol: ProtocolGoldSrc,
-		Timeout:  300 * time.Millisecond,
+		Timeout:  5 * time.Second,
 	})
 	require.NoError(t, err)
 	require.NoError(t, g.Open(context.Background()))
 	defer func() { _ = g.Close() }()
 
+	start := time.Now()
 	got, err := g.Execute(context.Background(), "status")
+	elapsed := time.Since(start)
+
 	require.NoError(t, err,
-		"a continuation-read timeout must be treated as end-of-response, not an error")
-	assert.Equal(t, firstPart, got, "the already-received part must be returned intact")
+		"an idle socket must be treated as end-of-response, not an error")
+	assert.Equal(t, part, got, "the received part must be returned intact")
+	assert.GreaterOrEqual(t, elapsed, responseIdleTimeout,
+		"Execute must wait out the idle window for possible follow-up datagrams")
+	assert.Less(t, elapsed, 3*time.Second,
+		"the idle timeout, not the full configured timeout, must end the read loop")
 }
 
 func TestGoldSource_Open_TimesOutOnSilentServer(t *testing.T) {
-	srv := newScriptedUDPServer(t, func(_ []byte, _ int) []byte {
+	srv := newScriptedUDPServer(t, func(_ []byte, _ int) [][]byte {
 		return nil // never answer the challenge request
 	})
 

--- a/pkg/quercon/rcon/goldsource_test.go
+++ b/pkg/quercon/rcon/goldsource_test.go
@@ -465,13 +465,16 @@ func TestGoldSource_Open_TimesOutOnSilentServer(t *testing.T) {
 func TestGoldSource_Execute_CapsReassembledResponse(t *testing.T) {
 	const challenge = "888"
 
-	// Enough back-to-back datagrams to exceed maxReassembledResponseSize with no idle gap.
+	// Enough datagrams to exceed maxReassembledResponseSize with no idle gap.
 	datagrams := make([][]byte, 0, maxReassembledResponseSize/4096+2)
 	for range maxReassembledResponseSize/4096 + 2 {
 		datagrams = append(datagrams, []byte(header+"\x00"+strings.Repeat("D", 4096)))
 	}
 
-	srv := newScriptedUDPServer(t, func(_ []byte, idx int) [][]byte {
+	// The datagrams are paced: an unpaced burst overruns the kernel receive buffer (as small
+	// as ~212 KiB on Linux) faster than the client can drain it, and the resulting packet
+	// loss — not the client-side cap — would end the response.
+	srv := newPacedScriptedUDPServer(t, 2*time.Millisecond, func(_ []byte, idx int) [][]byte {
 		switch idx {
 		case 0:
 			return [][]byte{[]byte(header + "\x00challenge rcon " + challenge + "\n")}
@@ -491,13 +494,6 @@ func TestGoldSource_Execute_CapsReassembledResponse(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, g.Open(context.Background()))
 	defer func() { _ = g.Close() }()
-
-	// The default OS UDP receive buffer (~768 KiB on macOS) is smaller than the cap;
-	// enlarge it so the whole burst fits and the test exercises the client-side cap
-	// instead of kernel-level datagram drops.
-	udpConn, ok := g.connection.(*net.UDPConn)
-	require.True(t, ok, "goldsource connection must be a *net.UDPConn")
-	require.NoError(t, udpConn.SetReadBuffer(4<<20))
 
 	got, err := g.Execute(context.Background(), "cvarlist")
 	require.NoError(t, err, "hitting the size cap must end the response normally, not error")

--- a/pkg/quercon/rcon/mock_server_test.go
+++ b/pkg/quercon/rcon/mock_server_test.go
@@ -74,9 +74,11 @@ func (s *scriptedTCPServer) Close() {
 
 // scriptedUDPServer reads one datagram at a time and answers via handler. handler returns the
 // response datagrams (each is written as a separate UDP packet); nil or empty means "do not reply".
+// writeDelay optionally paces the response datagrams of a multi-packet reply.
 type scriptedUDPServer struct {
-	conn net.PacketConn
-	addr string
+	conn       net.PacketConn
+	addr       string
+	writeDelay time.Duration
 
 	wg     sync.WaitGroup
 	closed chan struct{}
@@ -85,15 +87,26 @@ type scriptedUDPServer struct {
 func newScriptedUDPServer(t *testing.T, handler func(req []byte, idx int) [][]byte) *scriptedUDPServer {
 	t.Helper()
 
+	return newPacedScriptedUDPServer(t, 0, handler)
+}
+
+func newPacedScriptedUDPServer(
+	t *testing.T,
+	writeDelay time.Duration,
+	handler func(req []byte, idx int) [][]byte,
+) *scriptedUDPServer {
+	t.Helper()
+
 	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("scriptedUDPServer: listen: %v", err)
 	}
 
 	srv := &scriptedUDPServer{
-		conn:   pc,
-		addr:   pc.LocalAddr().String(),
-		closed: make(chan struct{}),
+		conn:       pc,
+		addr:       pc.LocalAddr().String(),
+		writeDelay: writeDelay,
+		closed:     make(chan struct{}),
 	}
 
 	srv.wg.Go(func() {
@@ -125,6 +138,11 @@ func newScriptedUDPServer(t *testing.T, handler func(req []byte, idx int) [][]by
 			idx++
 			for _, dgram := range resp {
 				_, _ = pc.WriteTo(dgram, peer)
+				// Pacing keeps a burst of response datagrams from overrunning the client's
+				// kernel receive buffer faster than the client can drain it.
+				if srv.writeDelay > 0 {
+					time.Sleep(srv.writeDelay)
+				}
 			}
 		}
 	})

--- a/pkg/quercon/rcon/mock_server_test.go
+++ b/pkg/quercon/rcon/mock_server_test.go
@@ -73,7 +73,7 @@ func (s *scriptedTCPServer) Close() {
 }
 
 // scriptedUDPServer reads one datagram at a time and answers via handler. handler returns the
-// raw response bytes; nil means "do not reply".
+// response datagrams (each is written as a separate UDP packet); nil or empty means "do not reply".
 type scriptedUDPServer struct {
 	conn net.PacketConn
 	addr string
@@ -82,7 +82,7 @@ type scriptedUDPServer struct {
 	closed chan struct{}
 }
 
-func newScriptedUDPServer(t *testing.T, handler func(req []byte, idx int) []byte) *scriptedUDPServer {
+func newScriptedUDPServer(t *testing.T, handler func(req []byte, idx int) [][]byte) *scriptedUDPServer {
 	t.Helper()
 
 	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
@@ -123,8 +123,8 @@ func newScriptedUDPServer(t *testing.T, handler func(req []byte, idx int) []byte
 
 			resp := handler(req, idx)
 			idx++
-			if resp != nil {
-				_, _ = pc.WriteTo(resp, peer)
+			for _, dgram := range resp {
+				_, _ = pc.WriteTo(dgram, peer)
 			}
 		}
 	})


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reassembly of multi-datagram RCON replies, including large/fragmented responses with correct boundary trimming.
  * Cleared any queued stale UDP packets and ensured late datagrams aren’t attributed to the next command.
  * Response collection now stops once the socket becomes idle, not only when the overall timeout elapses.
  * Added a safety limit to prevent excessively large reassembled responses.
  * Improved error reporting when UDP connection setup fails.

* **Tests**
  * Updated the scripted UDP harness to support multi-datagram replies and added coverage for reassembly, idle termination, stale/short packets, and response size caps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->