### PR TITLE
hide rcon password from output

### DIFF
--- a/internal/api/servers/getconsole/handler.go
+++ b/internal/api/servers/getconsole/handler.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gameap/gameap/internal/repositories"
 	"github.com/gameap/gameap/pkg/api"
 	"github.com/gameap/gameap/pkg/auth"
+	"github.com/gameap/gameap/pkg/secretmask"
 	"github.com/pkg/errors"
 )
 
@@ -119,6 +120,10 @@ func (h *Handler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 
 		return
 	}
+
+	// Game mod start commands embed the RCON password (+rcon_password {rcon_password}), so the
+	// launch line sits in the console log. Masking here covers every source getConsoleLog uses.
+	consoleOutput = secretmask.New(server.RconPassword()).String(consoleOutput)
 
 	h.responder.Write(ctx, rw, newConsoleResponse(consoleOutput))
 }

--- a/internal/api/servers/getconsole/handler_test.go
+++ b/internal/api/servers/getconsole/handler_test.go
@@ -68,6 +68,23 @@ func (m *mockDaemonCommands) ExecuteCommand(
 	return &daemon.CommandResult{Output: ""}, nil
 }
 
+type mockConsoleLogService struct {
+	getConsoleLogFunc func(ctx context.Context, nodeID uint64, serverID uint64, maxBytes int64) (string, error)
+}
+
+func (m *mockConsoleLogService) GetConsoleLog(
+	ctx context.Context,
+	nodeID uint64,
+	serverID uint64,
+	maxBytes int64,
+) (string, error) {
+	if m.getConsoleLogFunc != nil {
+		return m.getConsoleLogFunc(ctx, nodeID, serverID, maxBytes)
+	}
+
+	return "", errors.New("console log service unavailable")
+}
+
 func TestHandler_ServeHTTP(t *testing.T) {
 	tests := []struct {
 		name                 string
@@ -786,6 +803,211 @@ func TestHandler_ServeHTTP(t *testing.T) {
 				if tt.validateConsoleValue != nil {
 					tt.validateConsoleValue(t, resp.Console)
 				}
+			}
+		})
+	}
+}
+
+const testRconPassword = "s3cr3tRc0n"
+
+// seedServerWithRcon stores a node and a server whose RCON password is set, and grants the
+// console view ability to testUser1. scriptGetConsole may be empty to leave the node script
+// unset so the handler falls through to the output.txt download.
+func seedServerWithRcon(
+	t *testing.T,
+	serverRepo *inmemory.ServerRepository,
+	nodeRepo *inmemory.NodeRepository,
+	rbacRepo *inmemory.RBACRepository,
+	rconPassword string,
+	scriptGetConsole string,
+) {
+	t.Helper()
+
+	now := time.Now()
+
+	node := &domain.Node{
+		ID:            1,
+		Enabled:       true,
+		Name:          "test-node",
+		OS:            "linux",
+		WorkPath:      "/srv/gameap",
+		GdaemonHost:   "172.18.0.5",
+		GdaemonPort:   31717,
+		GdaemonAPIKey: "test-key",
+		CreatedAt:     &now,
+		UpdatedAt:     &now,
+	}
+	if scriptGetConsole != "" {
+		node.ScriptGetConsole = &scriptGetConsole
+	}
+	require.NoError(t, nodeRepo.Save(context.Background(), node))
+
+	server := &domain.Server{
+		ID:         1,
+		UID:        uuid.MustParse("11111111-1111-1111-1111-111111111111"),
+		UUIDShort:  "short1",
+		Enabled:    true,
+		Installed:  1,
+		Name:       "Test Server 1",
+		GameID:     "cs",
+		DSID:       1,
+		GameModID:  1,
+		ServerIP:   "127.0.0.1",
+		ServerPort: 27015,
+		Dir:        "/home/gameap/servers/test1",
+		CreatedAt:  &now,
+		UpdatedAt:  &now,
+	}
+	if rconPassword != "" {
+		server.Rcon = new(rconPassword)
+	}
+	require.NoError(t, serverRepo.Save(context.Background(), server))
+	serverRepo.AddUserServer(1, 1)
+
+	require.NoError(t, rbacRepo.Allow(
+		context.Background(),
+		testUser1.ID,
+		domain.EntityTypeUser,
+		[]domain.Ability{
+			{
+				Name:       domain.AbilityNameGameServerConsoleView,
+				EntityID:   new(uint(1)),
+				EntityType: lo.ToPtr(domain.EntityTypeServer),
+			},
+		},
+	))
+}
+
+func TestHandler_ServeHTTP_masksRconPassword(t *testing.T) {
+	const launchLine = "./hlds_run -game cs +ip 127.0.0.1 +port 27015 +rcon_password " +
+		testRconPassword + "\nServer running\n"
+
+	tests := []struct {
+		name             string
+		rconPassword     string
+		scriptGetConsole string
+		setupMockCLS     func() *mockConsoleLogService
+		setupMockDaemon  func() *mockDaemonCommands
+		setupMockFS      func() *mockFileService
+		wantConsole      string
+	}{
+		{
+			name:         "console_log_service_output_is_masked",
+			rconPassword: testRconPassword,
+			setupMockCLS: func() *mockConsoleLogService {
+				return &mockConsoleLogService{
+					getConsoleLogFunc: func(_ context.Context, _ uint64, _ uint64, _ int64) (string, error) {
+						return launchLine, nil
+					},
+				}
+			},
+			wantConsole: "./hlds_run -game cs +ip 127.0.0.1 +port 27015 +rcon_password ******\nServer running\n",
+		},
+		{
+			name:             "script_get_console_output_is_masked",
+			rconPassword:     testRconPassword,
+			scriptGetConsole: "cat {dir}/output.txt",
+			setupMockDaemon: func() *mockDaemonCommands {
+				return &mockDaemonCommands{
+					executeCommandFunc: func(
+						_ context.Context,
+						_ *domain.Node,
+						_ string,
+						_ ...daemon.CommandServiceOption,
+					) (*daemon.CommandResult, error) {
+						return &daemon.CommandResult{Output: launchLine}, nil
+					},
+				}
+			},
+			wantConsole: "./hlds_run -game cs +ip 127.0.0.1 +port 27015 +rcon_password ******\nServer running\n",
+		},
+		{
+			name:         "downloaded_output_file_is_masked",
+			rconPassword: testRconPassword,
+			setupMockFS: func() *mockFileService {
+				return &mockFileService{
+					downloadFunc: func(_ context.Context, _ *domain.Node, _ string) ([]byte, error) {
+						return []byte(launchLine), nil
+					},
+				}
+			},
+			wantConsole: "./hlds_run -game cs +ip 127.0.0.1 +port 27015 +rcon_password ******\nServer running\n",
+		},
+		{
+			name:         "every_occurrence_is_masked",
+			rconPassword: testRconPassword,
+			setupMockCLS: func() *mockConsoleLogService {
+				return &mockConsoleLogService{
+					getConsoleLogFunc: func(_ context.Context, _ uint64, _ uint64, _ int64) (string, error) {
+						return "rcon_password " + testRconPassword + "\n\"rcon_password\" = \"" +
+							testRconPassword + "\"\n", nil
+					},
+				}
+			},
+			wantConsole: "rcon_password ******\n\"rcon_password\" = \"******\"\n",
+		},
+		{
+			name:         "server_without_rcon_password_returns_console_unchanged",
+			rconPassword: "",
+			setupMockCLS: func() *mockConsoleLogService {
+				return &mockConsoleLogService{
+					getConsoleLogFunc: func(_ context.Context, _ uint64, _ uint64, _ int64) (string, error) {
+						return launchLine, nil
+					},
+				}
+			},
+			wantConsole: launchLine,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// ARRANGE
+			serverRepo := inmemory.NewServerRepository()
+			nodeRepo := inmemory.NewNodeRepository()
+			rbacRepo := inmemory.NewRBACRepository()
+			rbacService := rbac.NewRBAC(services.NewNilTransactionManager(), rbacRepo, 0)
+
+			seedServerWithRcon(t, serverRepo, nodeRepo, rbacRepo, tt.rconPassword, tt.scriptGetConsole)
+
+			mockFS := &mockFileService{}
+			if tt.setupMockFS != nil {
+				mockFS = tt.setupMockFS()
+			}
+
+			mockDaemon := &mockDaemonCommands{}
+			if tt.setupMockDaemon != nil {
+				mockDaemon = tt.setupMockDaemon()
+			}
+
+			var cls consoleLogService
+			if tt.setupMockCLS != nil {
+				cls = tt.setupMockCLS()
+			}
+
+			handler := NewHandler(serverRepo, nodeRepo, rbacService, mockDaemon, mockFS, cls, api.NewResponder())
+
+			req := httptest.NewRequest(http.MethodGet, "/api/servers/1/console", nil)
+			req = req.WithContext(auth.ContextWithSession(context.Background(), &auth.Session{
+				Login: "testuser",
+				Email: "test@example.com",
+				User:  &testUser1,
+			}))
+			req = mux.SetURLVars(req, map[string]string{"server": "1"})
+			w := httptest.NewRecorder()
+
+			// ACT
+			handler.ServeHTTP(w, req)
+
+			// ASSERT
+			require.Equal(t, http.StatusOK, w.Code)
+
+			var resp consoleResponse
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+			assert.Equal(t, tt.wantConsole, resp.Console)
+
+			if tt.rconPassword != "" {
+				assert.NotContains(t, resp.Console, tt.rconPassword)
 			}
 		})
 	}

--- a/internal/api/servers/getconsole/handler_test.go
+++ b/internal/api/servers/getconsole/handler_test.go
@@ -947,6 +947,30 @@ func TestHandler_ServeHTTP_masksRconPassword(t *testing.T) {
 			wantConsole: "rcon_password ******\n\"rcon_password\" = \"******\"\n",
 		},
 		{
+			name:         "two_character_password_is_masked",
+			rconPassword: "ab",
+			setupMockCLS: func() *mockConsoleLogService {
+				return &mockConsoleLogService{
+					getConsoleLogFunc: func(_ context.Context, _ uint64, _ uint64, _ int64) (string, error) {
+						return "+rcon_password ab\n", nil
+					},
+				}
+			},
+			wantConsole: "+rcon_password ******\n",
+		},
+		{
+			name:         "single_character_password_is_masked",
+			rconPassword: "x",
+			setupMockCLS: func() *mockConsoleLogService {
+				return &mockConsoleLogService{
+					getConsoleLogFunc: func(_ context.Context, _ uint64, _ uint64, _ int64) (string, error) {
+						return "+rcon_password x\n", nil
+					},
+				}
+			},
+			wantConsole: "+rcon_password ******\n",
+		},
+		{
 			name:         "server_without_rcon_password_returns_console_unchanged",
 			rconPassword: "",
 			setupMockCLS: func() *mockConsoleLogService {

--- a/internal/api/servers/rcon/postcommand/contracts.go
+++ b/internal/api/servers/rcon/postcommand/contracts.go
@@ -1,0 +1,7 @@
+package postcommand
+
+import "github.com/gameap/gameap/pkg/quercon/rcon"
+
+// rconClientFactory builds the RCON client the handler talks to. It exists so tests can
+// drive the handler without a live game server; production always uses rcon.NewClient.
+type rconClientFactory func(config rcon.Config) (rcon.Client, error)

--- a/internal/api/servers/rcon/postcommand/handler.go
+++ b/internal/api/servers/rcon/postcommand/handler.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gameap/gameap/pkg/api"
 	"github.com/gameap/gameap/pkg/auth"
 	"github.com/gameap/gameap/pkg/quercon/rcon"
+	"github.com/gameap/gameap/pkg/secretmask"
 	"github.com/pkg/errors"
 )
 
@@ -25,6 +26,7 @@ type Handler struct {
 	serverFinder   *serversbase.ServerFinder
 	abilityChecker *serversbase.AbilityChecker
 	gameRepo       repositories.GameRepository
+	newRconClient  rconClientFactory
 	responder      base.Responder
 }
 
@@ -38,6 +40,7 @@ func NewHandler(
 		serverFinder:   serversbase.NewServerFinder(serverRepo, rbac),
 		abilityChecker: serversbase.NewAbilityChecker(rbac),
 		gameRepo:       gameRepo,
+		newRconClient:  rcon.NewClient,
 		responder:      responder,
 	}
 }
@@ -118,6 +121,10 @@ func (h *Handler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 
 		return
 	}
+
+	// A game server happily echoes its own rcon_password cvar back (cvarlist, status and
+	// friends), so the reply is scrubbed before it reaches the RCON console.
+	output = secretmask.New(server.RconPassword()).String(output)
 
 	h.responder.Write(ctx, rw, newCommandResponse(output))
 }
@@ -202,7 +209,7 @@ func (h *Handler) executeRconCommand(
 		Timeout:  10 * time.Second,
 	}
 
-	client, err := rcon.NewClient(rconConfig)
+	client, err := h.newRconClient(rconConfig)
 	if err != nil {
 		return "", api.WrapHTTPError(
 			errors.WithMessage(err, "failed to create rcon client"),

--- a/internal/api/servers/rcon/postcommand/handler_test.go
+++ b/internal/api/servers/rcon/postcommand/handler_test.go
@@ -653,6 +653,18 @@ func TestHandler_ServeHTTP_masksRconPassword(t *testing.T) {
 			wantOutput:   "****** middle ******",
 		},
 		{
+			name:         "two_character_password_is_masked",
+			rconPassword: "ab",
+			rconOutput:   "\"rcon_password\" is \"ab\"\n",
+			wantOutput:   "\"rcon_password\" is \"******\"\n",
+		},
+		{
+			name:         "single_character_password_is_masked",
+			rconPassword: "x",
+			rconOutput:   "\"rcon_password\" is \"x\"\n",
+			wantOutput:   "\"rcon_password\" is \"******\"\n",
+		},
+		{
 			name:         "output_without_password_returned_unchanged",
 			rconPassword: testRconPassword,
 			rconOutput:   "hostname: Test Server\nplayers : 0 (32 max)\n",

--- a/internal/api/servers/rcon/postcommand/handler_test.go
+++ b/internal/api/servers/rcon/postcommand/handler_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gameap/gameap/internal/services"
 	"github.com/gameap/gameap/pkg/api"
 	"github.com/gameap/gameap/pkg/auth"
+	"github.com/gameap/gameap/pkg/quercon/rcon"
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
@@ -618,6 +619,131 @@ func TestHandler_ServeHTTP(t *testing.T) {
 	}
 }
 
+// stubRconClient answers Execute with a canned reply so the handler can be driven without a
+// live game server.
+type stubRconClient struct {
+	output string
+}
+
+func (c *stubRconClient) Open(_ context.Context) error { return nil }
+
+func (c *stubRconClient) Close() error { return nil }
+
+func (c *stubRconClient) Execute(_ context.Context, _ string) (string, error) {
+	return c.output, nil
+}
+
+func TestHandler_ServeHTTP_masksRconPassword(t *testing.T) {
+	tests := []struct {
+		name         string
+		rconPassword string
+		rconOutput   string
+		wantOutput   string
+	}{
+		{
+			name:         "cvar_dump_with_password_is_masked",
+			rconPassword: testRconPassword,
+			rconOutput:   "\"rcon_password\" is \"" + testRconPassword + "\"\n",
+			wantOutput:   "\"rcon_password\" is \"******\"\n",
+		},
+		{
+			name:         "every_occurrence_is_masked",
+			rconPassword: testRconPassword,
+			rconOutput:   testRconPassword + " middle " + testRconPassword,
+			wantOutput:   "****** middle ******",
+		},
+		{
+			name:         "output_without_password_returned_unchanged",
+			rconPassword: testRconPassword,
+			rconOutput:   "hostname: Test Server\nplayers : 0 (32 max)\n",
+			wantOutput:   "hostname: Test Server\nplayers : 0 (32 max)\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// ARRANGE
+			serverRepo := inmemory.NewServerRepository()
+			gameRepo := inmemory.NewGameRepository()
+			rbacRepo := inmemory.NewRBACRepository()
+			rbacService := rbac.NewRBAC(services.NewNilTransactionManager(), rbacRepo, 0)
+
+			seedOnlineServer(t, serverRepo, gameRepo, rbacRepo, tt.rconPassword)
+
+			handler := NewHandler(serverRepo, gameRepo, rbacService, api.NewResponder())
+			handler.newRconClient = func(_ rcon.Config) (rcon.Client, error) {
+				return &stubRconClient{output: tt.rconOutput}, nil
+			}
+
+			body, err := json.Marshal(map[string]string{"command": "cvarlist"})
+			require.NoError(t, err)
+
+			req := httptest.NewRequest(http.MethodPost, "/api/servers/1/rcon", bytes.NewReader(body))
+			req = req.WithContext(auth.ContextWithSession(context.Background(), &auth.Session{
+				Login: "testuser",
+				Email: "test@example.com",
+				User:  &testUser1,
+			}))
+			req = mux.SetURLVars(req, map[string]string{"server": "1"})
+			w := httptest.NewRecorder()
+
+			// ACT
+			handler.ServeHTTP(w, req)
+
+			// ASSERT
+			require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+			var response commandResponse
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+			assert.Equal(t, tt.wantOutput, response.Output)
+			assert.NotContains(t, response.Output, tt.rconPassword)
+		})
+	}
+}
+
+// seedOnlineServer stores an online server owned by testUser1 with the RCON console ability
+// granted, plus the game its protocol is derived from.
+func seedOnlineServer(
+	t *testing.T,
+	serverRepo *inmemory.ServerRepository,
+	gameRepo *inmemory.GameRepository,
+	rbacRepo *inmemory.RBACRepository,
+	rconPassword string,
+) {
+	t.Helper()
+
+	now := time.Now()
+
+	server := &domain.Server{
+		ID:               1,
+		UID:              uuid.MustParse("11111111-1111-1111-1111-111111111111"),
+		UUIDShort:        "short1",
+		Enabled:          true,
+		Installed:        1,
+		Name:             "Test Server 1",
+		GameID:           "cs",
+		DSID:             1,
+		GameModID:        1,
+		ServerIP:         "127.0.0.1",
+		ServerPort:       27015,
+		Rcon:             &rconPassword,
+		ProcessActive:    true,
+		LastProcessCheck: &now,
+		CreatedAt:        &now,
+		UpdatedAt:        &now,
+	}
+	require.NoError(t, serverRepo.Save(context.Background(), server))
+	serverRepo.AddUserServer(testUser1.ID, server.ID)
+
+	require.NoError(t, gameRepo.Save(context.Background(), &domain.Game{
+		Code:   "cs",
+		Name:   "Counter-Strike",
+		Engine: "goldsource",
+	}))
+
+	allowUserAbilityForServer(t, rbacRepo, testUser1.ID, server.ID, domain.AbilityNameGameServerRconConsole)
+}
+
 func TestHandler_NewHandler(t *testing.T) {
 	serverRepo := inmemory.NewServerRepository()
 	gameRepo := inmemory.NewGameRepository()
@@ -630,6 +756,7 @@ func TestHandler_NewHandler(t *testing.T) {
 	require.NotNil(t, handler)
 	assert.NotNil(t, handler.serverFinder)
 	assert.NotNil(t, handler.gameRepo)
+	assert.NotNil(t, handler.newRconClient)
 	assert.Equal(t, responder, handler.responder)
 }
 

--- a/internal/api/ws/attach/handler.go
+++ b/internal/api/ws/attach/handler.go
@@ -9,6 +9,7 @@ import (
 	"github.com/coder/websocket"
 	"github.com/gameap/gameap/internal/api/base"
 	serversbase "github.com/gameap/gameap/internal/api/servers/base"
+	wsbase "github.com/gameap/gameap/internal/api/ws/base"
 	"github.com/gameap/gameap/internal/domain"
 	"github.com/gameap/gameap/internal/filters"
 	"github.com/gameap/gameap/internal/grpc/handlers"
@@ -20,6 +21,7 @@ import (
 	"github.com/gameap/gameap/pkg/auth"
 	"github.com/gameap/gameap/pkg/idgen"
 	"github.com/gameap/gameap/pkg/proto"
+	"github.com/gameap/gameap/pkg/secretmask"
 	"github.com/pkg/errors"
 )
 
@@ -146,6 +148,10 @@ func (h *Handler) runAttachSession(
 	canSend bool,
 ) {
 	client := ws.NewClient(ctx, conn, h.hub, nil, h.logger)
+
+	// The game server prints its own launch line, RCON password included, into the PTY.
+	// Installed before Register so no broadcast can reach the peer unfiltered.
+	client.SetOutboundFilter(wsbase.NewOutboundMaskFilter(secretmask.New(server.RconPassword())))
 
 	startedTopic := ws.ChannelToTopic(channels.BuildRealtimeAttachStartedChannel(sessionID))
 	outputTopic := ws.ChannelToTopic(channels.BuildRealtimeAttachOutputChannel(sessionID))

--- a/internal/api/ws/attach/handler_grpc_test.go
+++ b/internal/api/ws/attach/handler_grpc_test.go
@@ -135,6 +135,93 @@ func TestRunAttachSession_grpcMode_relaysOutputToWS(t *testing.T) {
 	assert.Equal(t, []byte("hello-from-daemon"), payload.Data, "output bytes must be relayed unchanged")
 }
 
+// TestRunAttachSession_grpcMode_masksRconPasswordInOutput verifies that the server's RCON
+// password — which the game server prints as part of its launch command line — never reaches
+// the WebSocket client, whichever instance published the output.
+func TestRunAttachSession_grpcMode_masksRconPasswordInOutput(t *testing.T) {
+	const rconPassword = "s3cr3tRc0n"
+
+	tests := []struct {
+		name         string
+		rconPassword string
+		data         string
+		wantData     string
+	}{
+		{
+			name:         "launch_line_is_masked",
+			rconPassword: rconPassword,
+			data:         "./hlds_run -game cs +rcon_password " + rconPassword + "\r\n",
+			wantData:     "./hlds_run -game cs +rcon_password ******\r\n",
+		},
+		{
+			name:         "every_occurrence_is_masked",
+			rconPassword: rconPassword,
+			data:         rconPassword + " and " + rconPassword,
+			wantData:     "****** and ******",
+		},
+		{
+			name:         "output_without_password_is_relayed_unchanged",
+			rconPassword: rconPassword,
+			data:         "L 01/02/2026 - 12:00:00: Started map \"de_dust2\"\r\n",
+			wantData:     "L 01/02/2026 - 12:00:00: Started map \"de_dust2\"\r\n",
+		},
+		{
+			name:     "server_without_rcon_password_is_relayed_unchanged",
+			data:     "./hlds_run -game cs +rcon_password " + rconPassword + "\r\n",
+			wantData: "./hlds_run -game cs +rcon_password " + rconPassword + "\r\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// ARRANGE
+			var opts []attachEnvOption
+			if tt.rconPassword != "" {
+				opts = append(opts, withRconPassword(tt.rconPassword))
+			}
+
+			env := newAttachEnv(t, opts...)
+			conn := env.dial(t)
+
+			var sessionID string
+			require.Eventually(t, func() bool {
+				for _, m := range env.stream.sentMessages() {
+					if r := m.GetAttachRequest(); r != nil {
+						sessionID = r.SessionId
+
+						return true
+					}
+				}
+
+				return false
+			}, 2*time.Second, 10*time.Millisecond)
+			require.NotEmpty(t, sessionID, "session id must be discovered before publishing output")
+
+			// ACT
+			channel := channels.BuildRealtimeAttachOutputChannel(sessionID)
+			msg, err := messages.NewMessage(channel, messages.TypeAttachOutput, messages.AttachOutputPayload{
+				SessionID: sessionID,
+				Data:      []byte(tt.data),
+			})
+			require.NoError(t, err)
+			env.publishPubsub(t, channel, msg)
+
+			// ASSERT
+			frame, ok := readFrameOfType(t, conn, messages.TypeAttachOutput, 2*time.Second)
+			require.True(t, ok, "client must receive an attach.output frame")
+
+			var payload messages.AttachOutputPayload
+			require.NoError(t, json.Unmarshal(frame.Payload, &payload))
+			assert.Equal(t, sessionID, payload.SessionID, "session id must be carried through")
+			assert.Equal(t, tt.wantData, string(payload.Data))
+
+			if tt.rconPassword != "" {
+				assert.NotContains(t, string(payload.Data), tt.rconPassword)
+			}
+		})
+	}
+}
+
 // TestRunAttachSession_grpcMode_clientDetachClosesConnection verifies that an
 // attach.detach frame from the client triggers a detach gateway message and
 // closes the WebSocket connection.

--- a/internal/api/ws/attach/helpers_test.go
+++ b/internal/api/ws/attach/helpers_test.go
@@ -216,9 +216,20 @@ type attachEnv struct {
 	nodeRepo   *inmemory.NodeRepository
 }
 
+// attachEnvOption tweaks the fixture's server before it is stored.
+type attachEnvOption func(*domain.Server)
+
+// withRconPassword configures the fixture server with an RCON password, which is what the
+// handler masks out of the attach stream.
+func withRconPassword(password string) attachEnvOption {
+	return func(s *domain.Server) {
+		s.Rcon = &password
+	}
+}
+
 // newAttachEnv builds the fixture and registers a real local session for the
 // node so IsConnectedAnywhere returns true.
-func newAttachEnv(t *testing.T) *attachEnv {
+func newAttachEnv(t *testing.T, opts ...attachEnvOption) *attachEnv {
 	t.Helper()
 
 	const (
@@ -246,6 +257,10 @@ func newAttachEnv(t *testing.T) *attachEnv {
 		UID:        uuid.New(),
 	}
 	server.Hydrate()
+
+	for _, opt := range opts {
+		opt(server)
+	}
 
 	serverRepo := inmemory.NewServerRepository()
 	require.NoError(t, serverRepo.Save(t.Context(), server))

--- a/internal/api/ws/base/mask.go
+++ b/internal/api/ws/base/mask.go
@@ -23,11 +23,10 @@ type outboundFrame struct {
 // NewOutboundMaskFilter builds a ws.OutboundFilter that replaces every secret known to
 // masker with the placeholder before a frame reaches the browser.
 //
-// The two console-carrying payloads are masked on the decoded value, because their JSON
-// form can hide the secret from a plain text scan: attach.output holds raw PTY bytes,
-// which encode as base64, and a console.output chunk goes through JSON string escaping.
-// The encoded frame is then masked as well, which covers error messages and any frame
-// type added later.
+// Known payloads are masked on the decoded value, because their JSON form can hide the
+// secret from a plain text scan: attach.output holds raw PTY bytes, which encode as
+// base64, while console.output chunks and error messages go through JSON string escaping.
+// The encoded frame is then masked as well, which covers any frame type added later.
 //
 // Returns nil when there is nothing to mask, so callers can skip installing a filter
 // altogether.
@@ -37,38 +36,42 @@ func NewOutboundMaskFilter(masker *secretmask.Masker) ws.OutboundFilter {
 	}
 
 	return func(frame []byte) []byte {
-		return masker.Bytes(maskPayload(frame, masker))
+		return masker.Bytes(maskFrame(frame, masker))
 	}
 }
 
-// maskPayload rebuilds the frame around a masked payload. The frame is returned untouched
-// when it carries no known payload, cannot be decoded, or held no secret to begin with —
-// the caller still masks the encoded frame afterwards.
-func maskPayload(frame []byte, masker *secretmask.Masker) []byte {
+// maskFrame rebuilds the frame around a masked envelope and payload. The frame is returned
+// untouched when it cannot be decoded or held no secret to begin with — the caller still
+// masks the encoded frame afterwards.
+func maskFrame(frame []byte, masker *secretmask.Masker) []byte {
 	var decoded outboundFrame
 	if err := json.Unmarshal(frame, &decoded); err != nil {
 		return frame
 	}
 
-	var (
-		encodedPayload []byte
-		err            error
-	)
+	// The envelope's own error text is masked for every frame type, not just error frames.
+	maskedError := masker.String(decoded.Error)
+
+	var encodedPayload []byte
 
 	switch decoded.Type {
 	case messages.TypeAttachOutput:
-		encodedPayload, err = maskAttachOutput(decoded.Payload, masker)
+		encodedPayload = maskAttachOutput(decoded.Payload, masker)
 	case messages.TypeConsoleOutput:
-		encodedPayload, err = maskConsoleOutput(decoded.Payload, masker)
-	default:
+		encodedPayload = maskConsoleOutput(decoded.Payload, masker)
+	case ws.TypeError:
+		encodedPayload = maskErrorMessage(decoded.Payload, masker)
+	}
+
+	if encodedPayload == nil && maskedError == decoded.Error {
 		return frame
 	}
 
-	if err != nil || encodedPayload == nil {
-		return frame
+	if encodedPayload != nil {
+		decoded.Payload = encodedPayload
 	}
 
-	decoded.Payload = encodedPayload
+	decoded.Error = maskedError
 
 	encodedFrame, err := json.Marshal(decoded)
 	if err != nil {
@@ -78,38 +81,66 @@ func maskPayload(frame []byte, masker *secretmask.Masker) []byte {
 	return encodedFrame
 }
 
-// maskAttachOutput returns the re-encoded payload, or a nil payload when nothing was
-// masked.
-func maskAttachOutput(rawPayload json.RawMessage, masker *secretmask.Masker) ([]byte, error) {
+// maskAttachOutput returns the re-encoded payload, or nil when the payload could not be
+// decoded or carried no secret. A payload left alone is still covered by the caller's
+// mask over the encoded frame.
+func maskAttachOutput(rawPayload json.RawMessage, masker *secretmask.Masker) []byte {
 	var payload messages.AttachOutputPayload
 	if err := json.Unmarshal(rawPayload, &payload); err != nil {
-		return nil, err
+		return nil
 	}
 
 	masked := masker.Bytes(payload.Data)
 	if bytes.Equal(masked, payload.Data) {
-		return nil, nil //nolint:nilnil // "nothing to mask" is not an error here
+		return nil
 	}
 
 	payload.Data = masked
 
-	return json.Marshal(payload)
+	return marshalPayload(payload)
 }
 
-// maskConsoleOutput returns the re-encoded payload, or a nil payload when nothing was
-// masked.
-func maskConsoleOutput(rawPayload json.RawMessage, masker *secretmask.Masker) ([]byte, error) {
+// maskConsoleOutput returns the re-encoded payload, or nil when the payload could not be
+// decoded or carried no secret.
+func maskConsoleOutput(rawPayload json.RawMessage, masker *secretmask.Masker) []byte {
 	var payload messages.ConsoleOutputPayload
 	if err := json.Unmarshal(rawPayload, &payload); err != nil {
-		return nil, err
+		return nil
 	}
 
 	masked := masker.String(payload.Chunk)
 	if masked == payload.Chunk {
-		return nil, nil //nolint:nilnil // "nothing to mask" is not an error here
+		return nil
 	}
 
 	payload.Chunk = masked
 
-	return json.Marshal(payload)
+	return marshalPayload(payload)
+}
+
+// maskErrorMessage returns the re-encoded payload, or nil when the payload could not be
+// decoded or carried no secret.
+func maskErrorMessage(rawPayload json.RawMessage, masker *secretmask.Masker) []byte {
+	var payload ws.ErrorPayload
+	if err := json.Unmarshal(rawPayload, &payload); err != nil {
+		return nil
+	}
+
+	masked := masker.String(payload.Message)
+	if masked == payload.Message {
+		return nil
+	}
+
+	payload.Message = masked
+
+	return marshalPayload(payload)
+}
+
+func marshalPayload(payload any) []byte {
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		return nil
+	}
+
+	return encoded
 }

--- a/internal/api/ws/base/mask.go
+++ b/internal/api/ws/base/mask.go
@@ -1,0 +1,115 @@
+// Package base holds helpers shared by the WebSocket API handlers.
+package base
+
+import (
+	"bytes"
+	"encoding/json"
+
+	"github.com/gameap/gameap/internal/pubsub/messages"
+	"github.com/gameap/gameap/internal/ws"
+	"github.com/gameap/gameap/pkg/secretmask"
+)
+
+// outboundFrame mirrors ws.OutboundMessage with the payload left undecoded, so a frame can
+// be taken apart and put back together without losing envelope fields.
+type outboundFrame struct {
+	Type      string          `json:"type"`
+	Payload   json.RawMessage `json:"payload,omitempty"`
+	ID        string          `json:"id,omitempty"`
+	Timestamp int64           `json:"ts"`
+	Error     string          `json:"error,omitempty"`
+}
+
+// NewOutboundMaskFilter builds a ws.OutboundFilter that replaces every secret known to
+// masker with the placeholder before a frame reaches the browser.
+//
+// The two console-carrying payloads are masked on the decoded value, because their JSON
+// form can hide the secret from a plain text scan: attach.output holds raw PTY bytes,
+// which encode as base64, and a console.output chunk goes through JSON string escaping.
+// The encoded frame is then masked as well, which covers error messages and any frame
+// type added later.
+//
+// Returns nil when there is nothing to mask, so callers can skip installing a filter
+// altogether.
+func NewOutboundMaskFilter(masker *secretmask.Masker) ws.OutboundFilter {
+	if masker.Empty() {
+		return nil
+	}
+
+	return func(frame []byte) []byte {
+		return masker.Bytes(maskPayload(frame, masker))
+	}
+}
+
+// maskPayload rebuilds the frame around a masked payload. The frame is returned untouched
+// when it carries no known payload, cannot be decoded, or held no secret to begin with —
+// the caller still masks the encoded frame afterwards.
+func maskPayload(frame []byte, masker *secretmask.Masker) []byte {
+	var decoded outboundFrame
+	if err := json.Unmarshal(frame, &decoded); err != nil {
+		return frame
+	}
+
+	var (
+		encodedPayload []byte
+		err            error
+	)
+
+	switch decoded.Type {
+	case messages.TypeAttachOutput:
+		encodedPayload, err = maskAttachOutput(decoded.Payload, masker)
+	case messages.TypeConsoleOutput:
+		encodedPayload, err = maskConsoleOutput(decoded.Payload, masker)
+	default:
+		return frame
+	}
+
+	if err != nil || encodedPayload == nil {
+		return frame
+	}
+
+	decoded.Payload = encodedPayload
+
+	encodedFrame, err := json.Marshal(decoded)
+	if err != nil {
+		return frame
+	}
+
+	return encodedFrame
+}
+
+// maskAttachOutput returns the re-encoded payload, or a nil payload when nothing was
+// masked.
+func maskAttachOutput(rawPayload json.RawMessage, masker *secretmask.Masker) ([]byte, error) {
+	var payload messages.AttachOutputPayload
+	if err := json.Unmarshal(rawPayload, &payload); err != nil {
+		return nil, err
+	}
+
+	masked := masker.Bytes(payload.Data)
+	if bytes.Equal(masked, payload.Data) {
+		return nil, nil //nolint:nilnil // "nothing to mask" is not an error here
+	}
+
+	payload.Data = masked
+
+	return json.Marshal(payload)
+}
+
+// maskConsoleOutput returns the re-encoded payload, or a nil payload when nothing was
+// masked.
+func maskConsoleOutput(rawPayload json.RawMessage, masker *secretmask.Masker) ([]byte, error) {
+	var payload messages.ConsoleOutputPayload
+	if err := json.Unmarshal(rawPayload, &payload); err != nil {
+		return nil, err
+	}
+
+	masked := masker.String(payload.Chunk)
+	if masked == payload.Chunk {
+		return nil, nil //nolint:nilnil // "nothing to mask" is not an error here
+	}
+
+	payload.Chunk = masked
+
+	return json.Marshal(payload)
+}

--- a/internal/api/ws/base/mask_test.go
+++ b/internal/api/ws/base/mask_test.go
@@ -237,6 +237,61 @@ func TestNewOutboundMaskFilter_masksErrorFrames(t *testing.T) {
 	assert.Contains(t, string(masked), "rcon auth failed for ******")
 }
 
+func TestNewOutboundMaskFilter_masksJSONEscapedPasswordInErrorFrame(t *testing.T) {
+	const escapedPassword = `pa"ss\word`
+
+	// ARRANGE
+	filter := wsbase.NewOutboundMaskFilter(secretmask.New(escapedPassword))
+	require.NotNil(t, filter)
+
+	frame, err := json.Marshal(ws.NewErrorMessage("rcon auth failed for " + escapedPassword))
+	require.NoError(t, err)
+	require.NotContains(t, string(frame), escapedPassword,
+		"the escaped form is what makes this case interesting")
+
+	// ACT
+	masked := filter(frame)
+
+	// ASSERT
+	var decoded struct {
+		Type    string          `json:"type"`
+		Payload ws.ErrorPayload `json:"payload"`
+	}
+	require.NoError(t, json.Unmarshal(masked, &decoded))
+
+	assert.Equal(t, ws.TypeError, decoded.Type)
+	assert.Equal(t, "rcon auth failed for ******", decoded.Payload.Message)
+}
+
+func TestNewOutboundMaskFilter_masksEnvelopeErrorField(t *testing.T) {
+	const escapedPassword = `pa"ss\word`
+
+	// ARRANGE
+	filter := wsbase.NewOutboundMaskFilter(secretmask.New(escapedPassword))
+	require.NotNil(t, filter)
+
+	frame, err := json.Marshal(&ws.OutboundMessage{
+		Type:      messages.TypeConsoleOutput,
+		Timestamp: 1700000000,
+		Error:     "command rejected: " + escapedPassword,
+	})
+	require.NoError(t, err)
+
+	// ACT
+	masked := filter(frame)
+
+	// ASSERT
+	var decoded struct {
+		Type  string `json:"type"`
+		Error string `json:"error"`
+		Ts    int64  `json:"ts"`
+	}
+	require.NoError(t, json.Unmarshal(masked, &decoded))
+
+	assert.Equal(t, "command rejected: ******", decoded.Error)
+	assert.Equal(t, int64(1700000000), decoded.Ts)
+}
+
 func TestNewOutboundMaskFilter_masksMalformedFrames(t *testing.T) {
 	// ARRANGE
 	filter := wsbase.NewOutboundMaskFilter(secretmask.New(testRconPassword))

--- a/internal/api/ws/base/mask_test.go
+++ b/internal/api/ws/base/mask_test.go
@@ -1,0 +1,308 @@
+package base_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	wsbase "github.com/gameap/gameap/internal/api/ws/base"
+	"github.com/gameap/gameap/internal/pubsub/messages"
+	"github.com/gameap/gameap/internal/ws"
+	"github.com/gameap/gameap/pkg/secretmask"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testRconPassword = "s3cr3tRc0n"
+
+func encodeFrame(t *testing.T, msgType string, payload any) []byte {
+	t.Helper()
+
+	encodedPayload, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	frame, err := json.Marshal(ws.NewOutboundMessage(msgType, json.RawMessage(encodedPayload)))
+	require.NoError(t, err)
+
+	return frame
+}
+
+func TestNewOutboundMaskFilter_returns_nil_for_empty_masker(t *testing.T) {
+	tests := []struct {
+		name   string
+		masker *secretmask.Masker
+	}{
+		{name: "nil_masker", masker: nil},
+		{name: "masker_without_secrets", masker: secretmask.New()},
+		{name: "masker_with_empty_secret", masker: secretmask.New("")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// ACT
+			filter := wsbase.NewOutboundMaskFilter(tt.masker)
+
+			// ASSERT
+			assert.Nil(t, filter, "no secret means no filter should be installed")
+		})
+	}
+}
+
+func TestNewOutboundMaskFilter_masksAttachOutput(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     string
+		wantData string
+	}{
+		{
+			name:     "launch_line_with_password_is_masked",
+			data:     "./hlds_run -game cs +rcon_password " + testRconPassword + "\r\n",
+			wantData: "./hlds_run -game cs +rcon_password ******\r\n",
+		},
+		{
+			name:     "every_occurrence_is_masked",
+			data:     testRconPassword + " " + testRconPassword,
+			wantData: "****** ******",
+		},
+		{
+			name:     "chunk_without_password_is_untouched",
+			data:     "L 01/02/2026 - 12:00:00: Started map \"de_dust2\"\r\n",
+			wantData: "L 01/02/2026 - 12:00:00: Started map \"de_dust2\"\r\n",
+		},
+		{
+			name:     "empty_chunk_is_untouched",
+			data:     "",
+			wantData: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// ARRANGE
+			filter := wsbase.NewOutboundMaskFilter(secretmask.New(testRconPassword))
+			require.NotNil(t, filter)
+
+			frame := encodeFrame(t, messages.TypeAttachOutput, messages.AttachOutputPayload{
+				SessionID: "session-1",
+				Data:      []byte(tt.data),
+			})
+
+			// ACT
+			masked := filter(frame)
+
+			// ASSERT
+			var decoded struct {
+				Type    string                       `json:"type"`
+				Payload messages.AttachOutputPayload `json:"payload"`
+				Ts      int64                        `json:"ts"`
+			}
+			require.NoError(t, json.Unmarshal(masked, &decoded))
+
+			assert.Equal(t, messages.TypeAttachOutput, decoded.Type)
+			assert.Equal(t, "session-1", decoded.Payload.SessionID)
+			assert.Equal(t, tt.wantData, string(decoded.Payload.Data))
+			assert.NotContains(t, string(masked), testRconPassword)
+		})
+	}
+}
+
+func TestNewOutboundMaskFilter_masksConsoleOutputChunk(t *testing.T) {
+	// ARRANGE
+	filter := wsbase.NewOutboundMaskFilter(secretmask.New(testRconPassword))
+	require.NotNil(t, filter)
+
+	frame := encodeFrame(t, messages.TypeConsoleOutput, messages.ConsoleOutputPayload{
+		ServerID: 33,
+		Chunk:    "+rcon_password " + testRconPassword,
+	})
+
+	// ACT
+	masked := filter(frame)
+
+	// ASSERT
+	var decoded struct {
+		Type    string                        `json:"type"`
+		Payload messages.ConsoleOutputPayload `json:"payload"`
+	}
+	require.NoError(t, json.Unmarshal(masked, &decoded))
+
+	assert.Equal(t, messages.TypeConsoleOutput, decoded.Type)
+	assert.Equal(t, uint64(33), decoded.Payload.ServerID)
+	assert.Equal(t, "+rcon_password ******", decoded.Payload.Chunk)
+}
+
+// A password holding characters that JSON escapes ("\ and friends) never appears verbatim
+// in the encoded frame, so masking it depends on the payload being decoded first.
+func TestNewOutboundMaskFilter_masksJSONEscapedPassword(t *testing.T) {
+	const escapedPassword = `pa"ss\word`
+
+	tests := []struct {
+		name      string
+		frameType string
+		payload   any
+		wantValue string
+		readValue func(t *testing.T, payload json.RawMessage) string
+	}{
+		{
+			name:      "attach_output",
+			frameType: messages.TypeAttachOutput,
+			payload: messages.AttachOutputPayload{
+				SessionID: "session-1",
+				Data:      []byte("+rcon_password " + escapedPassword),
+			},
+			wantValue: "+rcon_password ******",
+			readValue: func(t *testing.T, payload json.RawMessage) string {
+				t.Helper()
+
+				var decoded messages.AttachOutputPayload
+				require.NoError(t, json.Unmarshal(payload, &decoded))
+
+				return string(decoded.Data)
+			},
+		},
+		{
+			name:      "console_output",
+			frameType: messages.TypeConsoleOutput,
+			payload: messages.ConsoleOutputPayload{
+				ServerID: 33,
+				Chunk:    "+rcon_password " + escapedPassword,
+			},
+			wantValue: "+rcon_password ******",
+			readValue: func(t *testing.T, payload json.RawMessage) string {
+				t.Helper()
+
+				var decoded messages.ConsoleOutputPayload
+				require.NoError(t, json.Unmarshal(payload, &decoded))
+
+				return decoded.Chunk
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// ARRANGE
+			filter := wsbase.NewOutboundMaskFilter(secretmask.New(escapedPassword))
+			require.NotNil(t, filter)
+
+			frame := encodeFrame(t, tt.frameType, tt.payload)
+			require.NotContains(t, string(frame), escapedPassword,
+				"the escaped form is what makes this case interesting")
+
+			// ACT
+			masked := filter(frame)
+
+			// ASSERT
+			var decoded struct {
+				Type    string          `json:"type"`
+				Payload json.RawMessage `json:"payload"`
+			}
+			require.NoError(t, json.Unmarshal(masked, &decoded))
+
+			assert.Equal(t, tt.frameType, decoded.Type)
+			assert.Equal(t, tt.wantValue, tt.readValue(t, decoded.Payload))
+		})
+	}
+}
+
+func TestNewOutboundMaskFilter_masksUnknownFrameTypes(t *testing.T) {
+	// ARRANGE
+	filter := wsbase.NewOutboundMaskFilter(secretmask.New(testRconPassword))
+	require.NotNil(t, filter)
+
+	frame := encodeFrame(t, "console.history", map[string]string{
+		"output": "+rcon_password " + testRconPassword,
+	})
+
+	// ACT
+	masked := filter(frame)
+
+	// ASSERT
+	assert.NotContains(t, string(masked), testRconPassword)
+	assert.Contains(t, string(masked), "+rcon_password ******")
+}
+
+func TestNewOutboundMaskFilter_masksErrorFrames(t *testing.T) {
+	// ARRANGE
+	filter := wsbase.NewOutboundMaskFilter(secretmask.New(testRconPassword))
+	require.NotNil(t, filter)
+
+	frame, err := json.Marshal(ws.NewErrorMessage("rcon auth failed for " + testRconPassword))
+	require.NoError(t, err)
+
+	// ACT
+	masked := filter(frame)
+
+	// ASSERT
+	assert.NotContains(t, string(masked), testRconPassword)
+	assert.Contains(t, string(masked), "rcon auth failed for ******")
+}
+
+func TestNewOutboundMaskFilter_masksMalformedFrames(t *testing.T) {
+	// ARRANGE
+	filter := wsbase.NewOutboundMaskFilter(secretmask.New(testRconPassword))
+	require.NotNil(t, filter)
+
+	frame := []byte("this is not json but contains " + testRconPassword)
+
+	// ACT
+	masked := filter(frame)
+
+	// ASSERT
+	assert.Equal(t, "this is not json but contains ******", string(masked))
+}
+
+func TestNewOutboundMaskFilter_preservesEnvelopeFields(t *testing.T) {
+	// ARRANGE
+	filter := wsbase.NewOutboundMaskFilter(secretmask.New(testRconPassword))
+	require.NotNil(t, filter)
+
+	encodedPayload, err := json.Marshal(messages.AttachOutputPayload{
+		SessionID: "session-1",
+		Data:      []byte("+rcon_password " + testRconPassword),
+	})
+	require.NoError(t, err)
+
+	original := &ws.OutboundMessage{
+		Type:      messages.TypeAttachOutput,
+		Payload:   json.RawMessage(encodedPayload),
+		ID:        "msg-7",
+		Timestamp: 1700000000,
+	}
+	frame, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	// ACT
+	masked := filter(frame)
+
+	// ASSERT
+	var decoded struct {
+		Type    string                       `json:"type"`
+		Payload messages.AttachOutputPayload `json:"payload"`
+		ID      string                       `json:"id"`
+		Ts      int64                        `json:"ts"`
+	}
+	require.NoError(t, json.Unmarshal(masked, &decoded))
+
+	assert.Equal(t, messages.TypeAttachOutput, decoded.Type)
+	assert.Equal(t, "msg-7", decoded.ID)
+	assert.Equal(t, int64(1700000000), decoded.Ts)
+	assert.Equal(t, "+rcon_password ******", string(decoded.Payload.Data))
+}
+
+func TestNewOutboundMaskFilter_returnsFrameAsIsWhenNothingMatches(t *testing.T) {
+	// ARRANGE
+	filter := wsbase.NewOutboundMaskFilter(secretmask.New(testRconPassword))
+	require.NotNil(t, filter)
+
+	frame := encodeFrame(t, messages.TypeAttachOutput, messages.AttachOutputPayload{
+		SessionID: "session-1",
+		Data:      []byte("nothing to hide"),
+	})
+
+	// ACT
+	masked := filter(frame)
+
+	// ASSERT
+	require.Len(t, masked, len(frame))
+	assert.Equal(t, &frame[0], &masked[0], "untouched frames must not be re-encoded")
+}

--- a/internal/api/ws/console/handler.go
+++ b/internal/api/ws/console/handler.go
@@ -8,6 +8,7 @@ import (
 	"github.com/coder/websocket"
 	"github.com/gameap/gameap/internal/api/base"
 	serversbase "github.com/gameap/gameap/internal/api/servers/base"
+	wsbase "github.com/gameap/gameap/internal/api/ws/base"
 	"github.com/gameap/gameap/internal/daemon"
 	"github.com/gameap/gameap/internal/domain"
 	"github.com/gameap/gameap/internal/filters"
@@ -18,6 +19,7 @@ import (
 	"github.com/gameap/gameap/internal/ws"
 	"github.com/gameap/gameap/pkg/api"
 	"github.com/gameap/gameap/pkg/auth"
+	"github.com/gameap/gameap/pkg/secretmask"
 	"github.com/pkg/errors"
 )
 
@@ -164,22 +166,38 @@ func (h *Handler) runGRPCMode(
 	client := ws.NewClient(ctx, conn, h.hub, nil, h.logger)
 	msgHandler, cleanup := h.newGRPCMessageHandler(ctx, client, server, node, user, canSend)
 	client.SetMessageHandler(msgHandler)
+
+	// The game server start command embeds the RCON password, so it shows up in the console
+	// stream. Installed before Register so no broadcast can reach the peer unfiltered.
+	masker := secretmask.New(server.RconPassword())
+	client.SetOutboundFilter(wsbase.NewOutboundMaskFilter(masker))
+
 	defer cleanup()
 
 	h.hub.Register(client, consoleTopic)
 
-	h.sendConsoleHistory(ctx, client, server, node)
+	h.sendConsoleHistory(ctx, client, server, node, masker)
 
 	client.Run()
 }
 
-func (h *Handler) sendConsoleHistory(ctx context.Context, client *ws.Client, server *domain.Server, node *domain.Node) {
+func (h *Handler) sendConsoleHistory(
+	ctx context.Context,
+	client *ws.Client,
+	server *domain.Server,
+	node *domain.Node,
+	masker *secretmask.Masker,
+) {
 	output, err := h.getConsoleLog(ctx, server, node)
 	if err != nil {
 		h.logger.Warn("failed to load console history", "server_id", server.ID, "error", err)
 
 		return
 	}
+
+	// Masked here rather than left to the outbound filter: the filter works on the encoded
+	// frame, where a password carrying JSON-escaped characters would no longer match.
+	output = masker.String(output)
 
 	if output != "" {
 		client.SendMessage(ws.NewOutboundMessage(typeConsoleHistory, consoleHistoryPayload{

--- a/internal/api/ws/console/handler_test.go
+++ b/internal/api/ws/console/handler_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gameap/gameap/internal/repositories/inmemory"
 	"github.com/gameap/gameap/internal/ws"
 	"github.com/gameap/gameap/pkg/auth"
+	"github.com/gameap/gameap/pkg/secretmask"
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
@@ -420,9 +421,10 @@ func TestHandler_sendConsoleHistory(t *testing.T) {
 	tests := []struct {
 		name string
 
-		logSvc *fakeConsoleLogService
-		dc     *fakeDaemonCommands
-		node   *domain.Node
+		logSvc       *fakeConsoleLogService
+		dc           *fakeDaemonCommands
+		node         *domain.Node
+		rconPassword string
 
 		wantFrame      bool
 		wantOutput     string
@@ -467,6 +469,27 @@ func TestHandler_sendConsoleHistory(t *testing.T) {
 			wantDCCalls:    0,
 			wantLogSvcHits: 1,
 		},
+		{
+			name:           "masks_rcon_password_in_history",
+			logSvc:         &fakeConsoleLogService{result: "./hlds_run +rcon_password s3cr3tRc0n\n"},
+			dc:             &fakeDaemonCommands{},
+			node:           newTestNode(nil),
+			rconPassword:   "s3cr3tRc0n",
+			wantFrame:      true,
+			wantOutput:     "./hlds_run +rcon_password ******\n",
+			wantDCCalls:    0,
+			wantLogSvcHits: 1,
+		},
+		{
+			name:           "leaves_history_untouched_without_rcon_password",
+			logSvc:         &fakeConsoleLogService{result: "./hlds_run +rcon_password s3cr3tRc0n\n"},
+			dc:             &fakeDaemonCommands{},
+			node:           newTestNode(nil),
+			wantFrame:      true,
+			wantOutput:     "./hlds_run +rcon_password s3cr3tRc0n\n",
+			wantDCCalls:    0,
+			wantLogSvcHits: 1,
+		},
 	}
 
 	for _, tt := range tests {
@@ -475,9 +498,14 @@ func TestHandler_sendConsoleHistory(t *testing.T) {
 			d := dialConsoleClient(t)
 			h := newConsoleLogTestHandler(tt.logSvc, tt.dc)
 			server := newTestServer()
+			if tt.rconPassword != "" {
+				server.Rcon = new(tt.rconPassword)
+			}
 
 			// ACT
-			h.sendConsoleHistory(context.Background(), d.srvClient, server, tt.node)
+			h.sendConsoleHistory(
+				context.Background(), d.srvClient, server, tt.node, secretmask.New(server.RconPassword()),
+			)
 
 			// ASSERT
 			assert.Equal(t, tt.wantLogSvcHits, tt.logSvc.calls.Load(),

--- a/internal/domain/server.go
+++ b/internal/domain/server.go
@@ -87,6 +87,15 @@ func (s *Server) XID() xid.ID {
 	return idgen.UUIDToXID(s.UID)
 }
 
+// RconPassword returns the configured RCON password, or an empty string when the server has none.
+func (s *Server) RconPassword() string {
+	if s.Rcon == nil {
+		return ""
+	}
+
+	return *s.Rcon
+}
+
 // ReplaceServerShortcodes replaces shortcode placeholders in a command string with server-specific values.
 // It first replaces any extra data provided, then replaces standard server shortcodes.
 // Shortcodes are replaced in the format {key} with their corresponding values.

--- a/internal/domain/server_test.go
+++ b/internal/domain/server_test.go
@@ -339,6 +339,43 @@ func TestServer_IsOnline(t *testing.T) {
 	}
 }
 
+func TestServer_RconPassword(t *testing.T) {
+	tests := []struct {
+		name string
+		rcon *string
+		want string
+	}{
+		{
+			name: "nil_rcon_returns_empty_string",
+			rcon: nil,
+			want: "",
+		},
+		{
+			name: "empty_rcon_returns_empty_string",
+			rcon: new(""),
+			want: "",
+		},
+		{
+			name: "configured_rcon_returns_password",
+			rcon: new("s3cr3tpass"),
+			want: "s3cr3tpass",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// ARRANGE
+			server := &Server{Rcon: test.rcon}
+
+			// ACT
+			got := server.RconPassword()
+
+			// ASSERT
+			assert.Equal(t, test.want, got)
+		})
+	}
+}
+
 func TestServerInstalledStatusConstants(t *testing.T) {
 	assert.Equal(t, ServerInstalledStatus(0), ServerInstalledStatusNotInstalled)
 	assert.Equal(t, ServerInstalledStatus(1), ServerInstalledStatusInstalled)

--- a/internal/ws/README.md
+++ b/internal/ws/README.md
@@ -34,8 +34,20 @@ All WebSocket messages use a JSON envelope:
 }
 ```
 
+## Outbound filter
+
+Frames delivered through `Hub.Broadcast` are already encoded by the time a `Client` sees
+them, so a handler cannot post-process them by wrapping `SendMessage`. `Client.SetOutboundFilter`
+installs a per-connection transform that runs on every outbound frame, whichever path it
+came from. It must be installed before `Hub.Register` and `Run`.
+
+The console endpoints use it to mask the server RCON password
+(`internal/api/ws/base.NewOutboundMaskFilter`), which the game server prints as part of its
+launch command line.
+
 ## Endpoints
 
 - `GET /api/ws/tasks/{id}?token=<bearer>` - Real-time task status and output
 - `GET /api/ws/servers/{server}/console?token=<bearer>` - Bidirectional server console
+- `GET /api/ws/servers/{server}/attach?token=<bearer>` - Interactive PTY session
 

--- a/internal/ws/client.go
+++ b/internal/ws/client.go
@@ -28,6 +28,17 @@ const (
 // is the Client's context and is cancelled when the connection is closed.
 type MessageHandler func(ctx context.Context, msg *InboundMessage)
 
+// OutboundFilter transforms an already-encoded outbound frame before it is
+// queued for delivery.
+//
+// It is the only place a Client can inspect traffic that reaches it through
+// Hub.Broadcast, which hands over frames that were encoded elsewhere (the
+// Bridge, from a PubSub payload). Returning the frame unchanged is the no-op
+// behaviour; returning a different slice replaces what the peer receives.
+// The filter runs on the caller's goroutine — the Hub fan-out or whoever
+// calls Send — so it must be cheap and safe for concurrent use.
+type OutboundFilter func(frame []byte) []byte
+
 // Client represents a single connected WebSocket peer on this API instance.
 //
 // Each Client owns its own bounded send channel and a context that is
@@ -50,6 +61,7 @@ type Client struct {
 	ctx     context.Context
 	cancel  context.CancelFunc
 	handler MessageHandler
+	filter  OutboundFilter
 	logger  *slog.Logger
 }
 
@@ -106,6 +118,17 @@ func (c *Client) SetMessageHandler(handler MessageHandler) {
 	c.handler = handler
 }
 
+// SetOutboundFilter installs filter as the transform applied to every frame
+// on its way to the peer, including frames fanned out by the Hub.
+//
+// There is no synchronization with the write path, so it must be installed
+// before the Client is registered with the Hub and before Run, the same
+// ordering requirement SetMessageHandler carries. Passing nil clears the
+// filter.
+func (c *Client) SetOutboundFilter(filter OutboundFilter) {
+	c.filter = filter
+}
+
 // Run starts the write pump in a new goroutine and blocks on the read pump
 // in the calling goroutine.
 //
@@ -121,11 +144,16 @@ func (c *Client) Run() {
 
 // Send enqueues msg onto the Client's bounded send buffer.
 //
-// The call is non-blocking: if the buffer is full the message is dropped
-// and a warning is logged, so a slow WebSocket peer cannot back-pressure
-// the Hub. This is the entry point used by Hub.Broadcast for fan-out.
-// Safe for concurrent use.
+// The installed OutboundFilter, if any, is applied first. The call is
+// non-blocking: if the buffer is full the message is dropped and a warning
+// is logged, so a slow WebSocket peer cannot back-pressure the Hub. This is
+// the entry point used by Hub.Broadcast for fan-out. Safe for concurrent
+// use.
 func (c *Client) Send(msg []byte) {
+	if c.filter != nil {
+		msg = c.filter(msg)
+	}
+
 	select {
 	case c.send <- msg:
 	default:

--- a/internal/ws/client.go
+++ b/internal/ws/client.go
@@ -122,9 +122,9 @@ func (c *Client) SetMessageHandler(handler MessageHandler) {
 // on its way to the peer, including frames fanned out by the Hub.
 //
 // There is no synchronization with the write path, so it must be installed
-// before the Client is registered with the Hub and before Run, the same
-// ordering requirement SetMessageHandler carries. Passing nil clears the
-// filter.
+// before the Client is registered with the Hub and before Run — once either
+// has happened another goroutine may already be calling Send. Passing nil
+// clears the filter.
 func (c *Client) SetOutboundFilter(filter OutboundFilter) {
 	c.filter = filter
 }

--- a/internal/ws/client_test.go
+++ b/internal/ws/client_test.go
@@ -1,6 +1,7 @@
 package ws
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"net/http"
@@ -67,6 +68,52 @@ func TestClient_Send_DropsOnFullBuffer(t *testing.T) {
 		assert.Equal(t, []byte("payload"), <-client.send)
 	}
 	assert.Empty(t, client.send, "no extra message should remain after draining")
+}
+
+func TestClient_Send_AppliesOutboundFilter(t *testing.T) {
+	client := NewClient(context.Background(), nil, NewHub(nil), nil, nil)
+	client.SetOutboundFilter(func(frame []byte) []byte {
+		return bytes.ReplaceAll(frame, []byte("secret"), []byte("******"))
+	})
+
+	client.Send([]byte("password is secret"))
+
+	require.Len(t, client.send, 1)
+	assert.Equal(t, []byte("password is ******"), <-client.send)
+}
+
+func TestClient_SendMessage_AppliesOutboundFilter(t *testing.T) {
+	client := NewClient(context.Background(), nil, NewHub(nil), nil, nil)
+	client.SetOutboundFilter(func(frame []byte) []byte {
+		return bytes.ReplaceAll(frame, []byte("secret"), []byte("******"))
+	})
+
+	client.SendMessage(NewOutboundMessage("console.output", map[string]any{"chunk": "secret"}))
+
+	require.Len(t, client.send, 1)
+	assert.Contains(t, string(<-client.send), `"chunk":"******"`)
+}
+
+func TestClient_Send_WithoutFilter_PassesThrough(t *testing.T) {
+	client := NewClient(context.Background(), nil, NewHub(nil), nil, nil)
+
+	client.Send([]byte("password is secret"))
+
+	require.Len(t, client.send, 1)
+	assert.Equal(t, []byte("password is secret"), <-client.send)
+}
+
+func TestClient_SetOutboundFilter_NilClearsFilter(t *testing.T) {
+	client := NewClient(context.Background(), nil, NewHub(nil), nil, nil)
+	client.SetOutboundFilter(func([]byte) []byte {
+		return []byte("filtered")
+	})
+	client.SetOutboundFilter(nil)
+
+	client.Send([]byte("original"))
+
+	require.Len(t, client.send, 1)
+	assert.Equal(t, []byte("original"), <-client.send)
 }
 
 func TestClient_SendMessage_MarshalsAndEnqueues(t *testing.T) {

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -133,6 +133,9 @@ info:
       `{ output: string }` with the buffered console contents (may be
       empty).
     - `console.output` — payload `{ chunk: string }` (streamed).
+
+    Occurrences of the server RCON password are replaced with `******`
+    in every outbound frame.
     - `error` — payload `{ message: string }` for authorization, daemon
       connectivity, or RPC failures. The envelope's top-level `error`
       field carries the same message. The server may close the socket
@@ -155,6 +158,9 @@ info:
       once after the daemon confirms attach.
     - `attach.output` — payload `{ data: bytes }`. PTY output, streamed.
     - `error` — same shape as the console endpoint.
+
+    Occurrences of the server RCON password are replaced with `******`
+    in every outbound frame.
 
     ### `MetricsWireResponse` shape
 

--- a/openapi/paths/servers-console.yaml
+++ b/openapi/paths/servers-console.yaml
@@ -3,7 +3,9 @@
     tags:
       - ServerConsole
     summary: Get console output
-    description: Returns the server console output
+    description: >
+      Returns the server console output. The server RCON password is masked
+      with `******` in the returned text.
     operationId: getConsole
     x-codeSamples:
       - lang: cURL

--- a/openapi/paths/servers-rcon.yaml
+++ b/openapi/paths/servers-rcon.yaml
@@ -3,7 +3,9 @@
     tags:
       - ServerRcon
     summary: Send RCON command
-    description: Sends a RCON command to the server
+    description: >
+      Sends a RCON command to the server. The server RCON password is masked
+      with `******` in the returned output.
     operationId: sendRconCommand
     parameters:
       - name: server
@@ -28,7 +30,9 @@
               properties:
                 output:
                   type: string
-                  description: RCON command output
+                  description: >
+                    RCON command output. Occurrences of the server RCON
+                    password are replaced with `******`.
       '401':
         description: Unauthorized
         content:

--- a/openapi/schemas/responses/ConsoleResponse.yaml
+++ b/openapi/schemas/responses/ConsoleResponse.yaml
@@ -3,7 +3,9 @@ description: Console output response
 properties:
   console:
     type: string
-    description: Console output
+    description: >
+      Console output. Occurrences of the server RCON password are replaced
+      with `******` before the output leaves the panel.
     example: "Server started successfully"
 required:
   - console

--- a/pkg/secretmask/secretmask.go
+++ b/pkg/secretmask/secretmask.go
@@ -9,18 +9,13 @@ package secretmask
 
 import (
 	"bytes"
+	"cmp"
 	"slices"
 	"strings"
 )
 
 // Placeholder is what every occurrence of a secret is replaced with.
 const Placeholder = "******"
-
-// minSecretLength keeps a very short secret from swallowing the whole output:
-// a one or two character value occurs constantly in ordinary console text, so
-// masking it would leave nothing readable. Panel generated RCON passwords are
-// 10 characters long.
-const minSecretLength = 3
 
 // Masker replaces a fixed set of secrets with Placeholder.
 //
@@ -33,14 +28,15 @@ type Masker struct {
 
 // New builds a Masker for the given secrets.
 //
-// Empty values, values shorter than minSecretLength, and duplicates are
-// dropped. When nothing is left the returned Masker is a no-op and reports
-// Empty.
+// Empty values and duplicates are dropped; when nothing is left the returned
+// Masker is a no-op and reports Empty. Every other value is masked however
+// short it is: a secret that leaks is worse than output a very short secret
+// over-matches in.
 func New(secrets ...string) *Masker {
 	filtered := make([]string, 0, len(secrets))
 
 	for _, secret := range secrets {
-		if len(secret) < minSecretLength {
+		if secret == "" {
 			continue
 		}
 
@@ -48,6 +44,12 @@ func New(secrets ...string) *Masker {
 			filtered = append(filtered, secret)
 		}
 	}
+
+	// Longest first, so a secret that contains another one is replaced whole rather than
+	// being broken up by the shorter match.
+	slices.SortStableFunc(filtered, func(a, b string) int {
+		return cmp.Compare(len(b), len(a))
+	})
 
 	return &Masker{secrets: filtered}
 }

--- a/pkg/secretmask/secretmask.go
+++ b/pkg/secretmask/secretmask.go
@@ -1,0 +1,102 @@
+// Package secretmask replaces secret values with a fixed placeholder in text
+// that is about to be shown to a user.
+//
+// It is meant for output the panel does not control the shape of — game server
+// console logs, RCON replies — where a secret such as the RCON password can
+// appear anywhere inside free-form text and therefore cannot be omitted at the
+// response-field level the way node daemon credentials are.
+package secretmask
+
+import (
+	"bytes"
+	"slices"
+	"strings"
+)
+
+// Placeholder is what every occurrence of a secret is replaced with.
+const Placeholder = "******"
+
+// minSecretLength keeps a very short secret from swallowing the whole output:
+// a one or two character value occurs constantly in ordinary console text, so
+// masking it would leave nothing readable. Panel generated RCON passwords are
+// 10 characters long.
+const minSecretLength = 3
+
+// Masker replaces a fixed set of secrets with Placeholder.
+//
+// A Masker is immutable after New and safe for concurrent use. The zero value
+// and a nil *Masker are valid no-op maskers, so call sites do not need nil
+// checks.
+type Masker struct {
+	secrets []string
+}
+
+// New builds a Masker for the given secrets.
+//
+// Empty values, values shorter than minSecretLength, and duplicates are
+// dropped. When nothing is left the returned Masker is a no-op and reports
+// Empty.
+func New(secrets ...string) *Masker {
+	filtered := make([]string, 0, len(secrets))
+
+	for _, secret := range secrets {
+		if len(secret) < minSecretLength {
+			continue
+		}
+
+		if !slices.Contains(filtered, secret) {
+			filtered = append(filtered, secret)
+		}
+	}
+
+	return &Masker{secrets: filtered}
+}
+
+// Empty reports whether the Masker has nothing to replace.
+//
+// Use it to skip installing a masking step at all when no secret is
+// configured.
+func (m *Masker) Empty() bool {
+	return m == nil || len(m.secrets) == 0
+}
+
+// String returns s with every occurrence of every secret replaced by
+// Placeholder. Input without any match is returned as is.
+func (m *Masker) String(s string) string {
+	if m.Empty() || s == "" {
+		return s
+	}
+
+	for _, secret := range m.secrets {
+		if !strings.Contains(s, secret) {
+			continue
+		}
+
+		s = strings.ReplaceAll(s, secret, Placeholder)
+	}
+
+	return s
+}
+
+// Bytes returns b with every occurrence of every secret replaced by
+// Placeholder.
+//
+// The input slice is never modified. When nothing matches the very same slice
+// is returned, so masking a stream of frames that carry no secret costs no
+// allocations.
+func (m *Masker) Bytes(b []byte) []byte {
+	if m.Empty() || len(b) == 0 {
+		return b
+	}
+
+	for _, secret := range m.secrets {
+		secretBytes := []byte(secret)
+		if !bytes.Contains(b, secretBytes) {
+			continue
+		}
+
+		b = bytes.ReplaceAll(b, secretBytes, []byte(Placeholder))
+	}
+
+	return b
+}

--- a/pkg/secretmask/secretmask_test.go
+++ b/pkg/secretmask/secretmask_test.go
@@ -28,16 +28,28 @@ func TestMasker_String(t *testing.T) {
 			want:    "console output",
 		},
 		{
-			name:    "secret_shorter_than_minimum_ignored",
+			name:    "two_character_secret_replaced",
 			secrets: []string{"ab"},
 			input:   "abcabc",
-			want:    "abcabc",
+			want:    "******c******c",
 		},
 		{
-			name:    "secret_of_minimum_length_replaced",
-			secrets: []string{"abc"},
-			input:   "value abc end",
+			name:    "single_character_secret_replaced",
+			secrets: []string{"x"},
+			input:   "axbxc",
+			want:    "a******b******c",
+		},
+		{
+			name:    "longer_secret_wins_over_contained_shorter_one",
+			secrets: []string{"ab", "abcd"},
+			input:   "value abcd end",
 			want:    "value ****** end",
+		},
+		{
+			name:    "shorter_secret_still_replaced_on_its_own",
+			secrets: []string{"abcd", "ab"},
+			input:   "abcd and ab",
+			want:    "****** and ******",
 		},
 		{
 			name:    "single_occurrence_replaced",
@@ -199,11 +211,18 @@ func TestMasker_Empty(t *testing.T) {
 			wantOut: "+rcon_password s3cr3tpass",
 		},
 		{
-			name:    "masker_with_only_short_secrets_is_empty",
-			masker:  secretmask.New("", "ab"),
+			name:    "masker_with_only_empty_secrets_is_empty",
+			masker:  secretmask.New("", ""),
 			want:    true,
 			input:   "ab cd",
 			wantOut: "ab cd",
+		},
+		{
+			name:    "masker_with_short_secret_is_not_empty",
+			masker:  secretmask.New("", "ab"),
+			want:    false,
+			input:   "ab cd",
+			wantOut: "****** cd",
 		},
 		{
 			name:    "masker_with_secret_is_not_empty",
@@ -227,6 +246,17 @@ func TestMasker_Empty(t *testing.T) {
 			assert.Equal(t, tt.wantOut, string(maskedBytes))
 		})
 	}
+}
+
+func TestMasker_Bytes_masksShortSecret(t *testing.T) {
+	// ARRANGE
+	masker := secretmask.New("ab")
+
+	// ACT
+	got := masker.Bytes([]byte("+rcon_password ab"))
+
+	// ASSERT
+	assert.Equal(t, "+rcon_password ******", string(got))
 }
 
 func TestPlaceholder_hides_secret_length(t *testing.T) {

--- a/pkg/secretmask/secretmask_test.go
+++ b/pkg/secretmask/secretmask_test.go
@@ -1,0 +1,244 @@
+package secretmask_test
+
+import (
+	"testing"
+
+	"github.com/gameap/gameap/pkg/secretmask"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMasker_String(t *testing.T) {
+	tests := []struct {
+		name    string
+		secrets []string
+		input   string
+		want    string
+	}{
+		{
+			name:    "no_secrets_returns_input_unchanged",
+			secrets: nil,
+			input:   "./hlds_run +rcon_password s3cr3tpass",
+			want:    "./hlds_run +rcon_password s3cr3tpass",
+		},
+		{
+			name:    "empty_secret_ignored",
+			secrets: []string{""},
+			input:   "console output",
+			want:    "console output",
+		},
+		{
+			name:    "secret_shorter_than_minimum_ignored",
+			secrets: []string{"ab"},
+			input:   "abcabc",
+			want:    "abcabc",
+		},
+		{
+			name:    "secret_of_minimum_length_replaced",
+			secrets: []string{"abc"},
+			input:   "value abc end",
+			want:    "value ****** end",
+		},
+		{
+			name:    "single_occurrence_replaced",
+			secrets: []string{"s3cr3tpass"},
+			input:   "./hlds_run -game cs +rcon_password s3cr3tpass +port 27015",
+			want:    "./hlds_run -game cs +rcon_password ****** +port 27015",
+		},
+		{
+			name:    "multiple_occurrences_replaced",
+			secrets: []string{"s3cr3tpass"},
+			input:   "rcon_password s3cr3tpass\nrcon_password is s3cr3tpass",
+			want:    "rcon_password ******\nrcon_password is ******",
+		},
+		{
+			name:    "multiple_secrets_replaced",
+			secrets: []string{"s3cr3tpass", "another"},
+			input:   "first s3cr3tpass second another",
+			want:    "first ****** second ******",
+		},
+		{
+			name:    "duplicate_secrets_deduped",
+			secrets: []string{"s3cr3tpass", "s3cr3tpass"},
+			input:   "value s3cr3tpass",
+			want:    "value ******",
+		},
+		{
+			name:    "unicode_secret_replaced",
+			secrets: []string{"пароль123"},
+			input:   "rcon_password пароль123 done",
+			want:    "rcon_password ****** done",
+		},
+		{
+			name:    "secret_inside_word_replaced",
+			secrets: []string{"s3cr3tpass"},
+			input:   `+rcon_password "s3cr3tpass"`,
+			want:    `+rcon_password "******"`,
+		},
+		{
+			name:    "empty_input_returns_empty",
+			secrets: []string{"s3cr3tpass"},
+			input:   "",
+			want:    "",
+		},
+		{
+			name:    "input_without_secret_unchanged",
+			secrets: []string{"s3cr3tpass"},
+			input:   "L 01/02/2026 - 12:00:00: Started map \"de_dust2\"",
+			want:    "L 01/02/2026 - 12:00:00: Started map \"de_dust2\"",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// ARRANGE
+			masker := secretmask.New(tt.secrets...)
+
+			// ACT
+			got := masker.String(tt.input)
+
+			// ASSERT
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestMasker_Bytes(t *testing.T) {
+	tests := []struct {
+		name    string
+		secrets []string
+		input   []byte
+		want    []byte
+	}{
+		{
+			name:    "no_secrets_returns_input_unchanged",
+			secrets: nil,
+			input:   []byte("+rcon_password s3cr3tpass"),
+			want:    []byte("+rcon_password s3cr3tpass"),
+		},
+		{
+			name:    "single_occurrence_replaced",
+			secrets: []string{"s3cr3tpass"},
+			input:   []byte("+rcon_password s3cr3tpass"),
+			want:    []byte("+rcon_password ******"),
+		},
+		{
+			name:    "multiple_secrets_replaced",
+			secrets: []string{"s3cr3tpass", "another"},
+			input:   []byte("s3cr3tpass and another"),
+			want:    []byte("****** and ******"),
+		},
+		{
+			name:    "nil_input_returns_nil",
+			secrets: []string{"s3cr3tpass"},
+			input:   nil,
+			want:    nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// ARRANGE
+			masker := secretmask.New(tt.secrets...)
+
+			// ACT
+			got := masker.Bytes(tt.input)
+
+			// ASSERT
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestMasker_Bytes_does_not_modify_input(t *testing.T) {
+	// ARRANGE
+	masker := secretmask.New("s3cr3tpass")
+	input := []byte("+rcon_password s3cr3tpass")
+
+	// ACT
+	got := masker.Bytes(input)
+
+	// ASSERT
+	assert.Equal(t, []byte("+rcon_password ******"), got)
+	assert.Equal(t, []byte("+rcon_password s3cr3tpass"), input)
+}
+
+func TestMasker_Bytes_returns_same_slice_when_no_match(t *testing.T) {
+	// ARRANGE
+	masker := secretmask.New("s3cr3tpass")
+	input := []byte("nothing to hide here")
+
+	// ACT
+	got := masker.Bytes(input)
+
+	// ASSERT
+	require.Len(t, got, len(input))
+	assert.Equal(t, &input[0], &got[0], "slice must be returned as is when nothing matches")
+}
+
+func TestMasker_Empty(t *testing.T) {
+	tests := []struct {
+		name    string
+		masker  *secretmask.Masker
+		want    bool
+		input   string
+		wantOut string
+	}{
+		{
+			name:    "nil_masker_is_empty_and_noop",
+			masker:  nil,
+			want:    true,
+			input:   "+rcon_password s3cr3tpass",
+			wantOut: "+rcon_password s3cr3tpass",
+		},
+		{
+			name:    "masker_without_secrets_is_empty",
+			masker:  secretmask.New(),
+			want:    true,
+			input:   "+rcon_password s3cr3tpass",
+			wantOut: "+rcon_password s3cr3tpass",
+		},
+		{
+			name:    "masker_with_only_short_secrets_is_empty",
+			masker:  secretmask.New("", "ab"),
+			want:    true,
+			input:   "ab cd",
+			wantOut: "ab cd",
+		},
+		{
+			name:    "masker_with_secret_is_not_empty",
+			masker:  secretmask.New("s3cr3tpass"),
+			want:    false,
+			input:   "+rcon_password s3cr3tpass",
+			wantOut: "+rcon_password ******",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// ACT
+			empty := tt.masker.Empty()
+			masked := tt.masker.String(tt.input)
+			maskedBytes := tt.masker.Bytes([]byte(tt.input))
+
+			// ASSERT
+			assert.Equal(t, tt.want, empty)
+			assert.Equal(t, tt.wantOut, masked)
+			assert.Equal(t, tt.wantOut, string(maskedBytes))
+		})
+	}
+}
+
+func TestPlaceholder_hides_secret_length(t *testing.T) {
+	// ARRANGE
+	short := secretmask.New("abcd")
+	long := secretmask.New("averylongrconpassword")
+
+	// ACT
+	shortMasked := short.String("pass abcd")
+	longMasked := long.String("pass averylongrconpassword")
+
+	// ASSERT
+	assert.Equal(t, "pass "+secretmask.Placeholder, shortMasked)
+	assert.Equal(t, "pass "+secretmask.Placeholder, longMasked)
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * RCON passwords are now masked as `******` in console output, command responses, downloaded logs, and live WebSocket streams.
  * Repeated password occurrences are masked consistently, while servers without configured passwords remain unchanged.

* **Documentation**
  * API documentation now describes password masking for console, RCON, and WebSocket responses.
  * Added documentation for outbound WebSocket filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->