### PR TITLE
database connection backoff

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,9 @@ POSTGRES_PASSWORD=gameap
 # SQLite example (comment out PostgreSQL and uncomment this)
 # DATABASE_URL=file:/var/lib/gameap/db.sqlite?_busy_timeout=5000&_journal_mode=WAL&cache=shared
 
+# How long to retry the initial database connect at startup before giving up
+# DATABASE_CONNECT_TIMEOUT=30s
+
 # Cache Configuration
 CACHE_DRIVER=redis
 CACHE_REDIS_ADDR=redis:6379

--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ state, useful for monitoring dashboards and the `gameapctl` polling logic:
 
 - `DATABASE_DRIVER` - Database driver (required, options: `mysql`, `postgres`, `sqlite`, `inmemory`)
 - `DATABASE_URL` - Database connection URL (required)
+- `DATABASE_CONNECT_TIMEOUT` - How long to retry the initial database connect at startup (default: `30s`)
   - MySQL: `username:password@tcp(host:port)/database?parseTime=true`
   - PostgreSQL: `postgres://username:password@host:port/database?sslmode=disable`
   - SQLite: `file:path/to/database.db?_busy_timeout=5000&_journal_mode=WAL&cache=shared` (parameters recommended for production)

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -431,6 +431,7 @@ Key configuration:
 |----------|-------------|
 | `DATABASE_DRIVER` | mysql, postgres, sqlite, inmemory |
 | `DATABASE_URL` | Connection string |
+| `DATABASE_CONNECT_TIMEOUT` | Startup connect retry window; default `30s` |
 | `CACHE_DRIVER` | memory, redis |
 | `FILES_DRIVER` | local, s3 |
 | `AUTH_SERVICE` | paseto (default) |

--- a/internal/application/container.go
+++ b/internal/application/container.go
@@ -475,14 +475,21 @@ const (
 
 // Retries the initial ping within Config.DatabaseConnectTimeout so a database
 // that is briefly unavailable (restarting alongside the panel, still booting)
-// does not bring the process down.
+// does not bring the process down. The window bounds blocked ping attempts and
+// retry waits alike; a non-positive timeout means a single unbounded attempt.
 func (c *Container) pingDBWithRetry(db *sql.DB) error {
 	ctx := c.context
 	if ctx == nil {
 		ctx = context.Background()
 	}
 
-	deadline := time.Now().Add(c.config.DatabaseConnectTimeout)
+	if c.config.DatabaseConnectTimeout <= 0 {
+		return db.PingContext(ctx)
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, c.config.DatabaseConnectTimeout)
+	defer cancel()
+
 	delay := dbPingRetryInitialDelay
 
 	for {
@@ -491,7 +498,7 @@ func (c *Container) pingDBWithRetry(db *sql.DB) error {
 			return nil
 		}
 
-		if ctx.Err() != nil || time.Now().Add(delay).After(deadline) {
+		if ctx.Err() != nil {
 			return err
 		}
 

--- a/internal/application/container.go
+++ b/internal/application/container.go
@@ -460,12 +460,55 @@ func (c *Container) createDB() (*sql.DB, error) {
 		return nil, errors.Wrap(err, "failed to connect to database")
 	}
 
-	err = db.PingContext(c.context)
+	err = c.pingDBWithRetry(db)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to ping database")
 	}
 
 	return db, nil
+}
+
+const (
+	dbPingRetryInitialDelay = 500 * time.Millisecond
+	dbPingRetryMaxDelay     = 5 * time.Second
+)
+
+// Retries the initial ping within Config.DatabaseConnectTimeout so a database
+// that is briefly unavailable (restarting alongside the panel, still booting)
+// does not bring the process down.
+func (c *Container) pingDBWithRetry(db *sql.DB) error {
+	ctx := c.context
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	deadline := time.Now().Add(c.config.DatabaseConnectTimeout)
+	delay := dbPingRetryInitialDelay
+
+	for {
+		err := db.PingContext(ctx)
+		if err == nil {
+			return nil
+		}
+
+		if ctx.Err() != nil || time.Now().Add(delay).After(deadline) {
+			return err
+		}
+
+		slog.Warn(
+			"database not ready, retrying",
+			slog.String("error", err.Error()),
+			slog.Duration("retry_in", delay),
+		)
+
+		select {
+		case <-ctx.Done():
+			return err
+		case <-time.After(delay):
+		}
+
+		delay = min(delay*2, dbPingRetryMaxDelay)
+	}
 }
 
 func (c *Container) TransactionalDB() base.DB {

--- a/internal/application/container_db_test.go
+++ b/internal/application/container_db_test.go
@@ -67,6 +67,56 @@ func TestPingDBWithRetry_WindowExhausted(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestPingDBWithRetry_BlockedPing(t *testing.T) {
+	db, mock := newPingMonitoredDB(t)
+	mock.ExpectPing().WillDelayFor(10 * time.Second)
+
+	cfg := &config.Config{DatabaseConnectTimeout: 200 * time.Millisecond}
+	c := newMinimalContainer(cfg)
+
+	start := time.Now()
+	err := c.pingDBWithRetry(db)
+
+	require.Error(t, err)
+	assert.Less(t, time.Since(start), 5*time.Second,
+		"a ping blocked longer than the window must be cut off by the deadline")
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestPingDBWithRetry_FinalPartialWait(t *testing.T) {
+	db, mock := newPingMonitoredDB(t)
+	mock.ExpectPing().WillReturnError(errDBShuttingDown)
+
+	cfg := &config.Config{DatabaseConnectTimeout: 300 * time.Millisecond}
+	c := newMinimalContainer(cfg)
+
+	start := time.Now()
+	err := c.pingDBWithRetry(db)
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errDBShuttingDown)
+	assert.GreaterOrEqual(t, elapsed, 250*time.Millisecond,
+		"the remaining window must be waited out even when shorter than the next delay")
+	assert.Less(t, elapsed, 5*time.Second)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestPingDBWithRetry_RetriesDisabled(t *testing.T) {
+	db, mock := newPingMonitoredDB(t)
+	mock.ExpectPing().WillReturnError(errConnectionRefused)
+
+	c := newMinimalContainer(&config.Config{})
+
+	start := time.Now()
+	err := c.pingDBWithRetry(db)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errConnectionRefused)
+	assert.Less(t, time.Since(start), time.Second, "non-positive timeout must mean a single attempt")
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestPingDBWithRetry_ContextCancelled(t *testing.T) {
 	db, mock := newPingMonitoredDB(t)
 	mock.ExpectPing().WillReturnError(errConnectionRefused)

--- a/internal/application/container_db_test.go
+++ b/internal/application/container_db_test.go
@@ -1,0 +1,101 @@
+// White-box coverage for the DB startup ping retry (pingDBWithRetry): a
+// transiently unavailable database must be retried with backoff within
+// Config.DatabaseConnectTimeout, while context cancellation and an exhausted
+// window must surface the last ping error. Uses go-sqlmock ping monitoring, so
+// no live database handle is needed.
+
+package application
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/gameap/gameap/internal/config"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	errDBShuttingDown    = errors.New("FATAL: the database system is shutting down")
+	errConnectionRefused = errors.New("connect: connection refused")
+)
+
+func newPingMonitoredDB(t *testing.T) (*sql.DB, sqlmock.Sqlmock) {
+	t.Helper()
+
+	db, mock, err := sqlmock.New(sqlmock.MonitorPingsOption(true))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = db.Close()
+	})
+
+	return db, mock
+}
+
+func TestPingDBWithRetry_TransientFailures(t *testing.T) {
+	db, mock := newPingMonitoredDB(t)
+	mock.ExpectPing().WillReturnError(errDBShuttingDown)
+	mock.ExpectPing().WillReturnError(errConnectionRefused)
+	mock.ExpectPing()
+
+	cfg := &config.Config{DatabaseConnectTimeout: 30 * time.Second}
+	c := newMinimalContainer(cfg)
+
+	err := c.pingDBWithRetry(db)
+
+	require.NoError(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestPingDBWithRetry_WindowExhausted(t *testing.T) {
+	db, mock := newPingMonitoredDB(t)
+	mock.ExpectPing().WillReturnError(errDBShuttingDown)
+
+	cfg := &config.Config{DatabaseConnectTimeout: 100 * time.Millisecond}
+	c := newMinimalContainer(cfg)
+
+	start := time.Now()
+	err := c.pingDBWithRetry(db)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errDBShuttingDown)
+	assert.Less(t, time.Since(start), 5*time.Second)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestPingDBWithRetry_ContextCancelled(t *testing.T) {
+	db, mock := newPingMonitoredDB(t)
+	mock.ExpectPing().WillReturnError(errConnectionRefused)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cfg := &config.Config{DatabaseConnectTimeout: 30 * time.Second}
+	c := NewContainer(cfg)
+	c.context = ctx
+
+	time.AfterFunc(50*time.Millisecond, cancel)
+
+	start := time.Now()
+	err := c.pingDBWithRetry(db)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errConnectionRefused)
+	assert.Less(t, time.Since(start), 5*time.Second)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestPingDBWithRetry_NilContext(t *testing.T) {
+	db, mock := newPingMonitoredDB(t)
+	mock.ExpectPing()
+
+	cfg := &config.Config{DatabaseConnectTimeout: 30 * time.Second}
+	c := NewContainer(cfg)
+
+	err := c.pingDBWithRetry(db)
+
+	require.NoError(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}

--- a/internal/application/container_factories_test.go
+++ b/internal/application/container_factories_test.go
@@ -6,7 +6,8 @@
 // Deliberately NOT exercised here, and why:
 //   - DB() / createDB()      — open + PingContext require a live database handle;
 //     newWiredContainer injects c.db directly so these construction paths are
-//     never reached, and the ping cannot succeed against a closed/in-memory DSN.
+//     never reached. The startup ping retry (pingDBWithRetry) is covered in
+//     container_db_test.go via go-sqlmock ping monitoring.
 //   - Redis / Postgres cache + pub-sub branches — there is no miniredis or
 //     Postgres in the test environment (only go-sqlmock + modernc.org/sqlite).
 //   - ACMEService() / its Start — would dial a real ACME directory / open a

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -46,6 +46,11 @@ type Config struct {
 	DatabaseDriver string `env:"DATABASE_DRIVER,required" envDefault:"mysql"`
 	DatabaseURL    string `env:"DATABASE_URL,required,notEmpty"`
 
+	// DatabaseConnectTimeout bounds the initial connect at startup: transient
+	// database unavailability (restart during upgrades, slow boot ordering) is
+	// retried with backoff within this window instead of crashing immediately.
+	DatabaseConnectTimeout time.Duration `env:"DATABASE_CONNECT_TIMEOUT" envDefault:"30s"`
+
 	EncryptionKey string `env:"ENCRYPTION_KEY" envDefault:""`
 	AuthSecret    string `env:"AUTH_SECRET,required,notEmpty" envDefault:""`
 	AuthService   string `env:"AUTH_SERVICE" envDefault:"paseto"`

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -56,6 +56,7 @@ func TestLoadConfig(t *testing.T) {
 		assert.Equal(t, uint16(8025), cfg.HTTPPort)
 		assert.Equal(t, uint16(443), cfg.HTTPSPort)
 		assert.Equal(t, "mysql", cfg.DatabaseDriver)
+		assert.Equal(t, 30*time.Second, cfg.DatabaseConnectTimeout)
 		assert.Equal(t, "paseto", cfg.AuthService)
 		assert.Equal(t, "30s", cfg.RBAC.CacheTTL)
 		assert.Equal(t, "memory", cfg.Cache.Driver)
@@ -63,6 +64,17 @@ func TestLoadConfig(t *testing.T) {
 		assert.Equal(t, "info", cfg.Logger.Level)
 		assert.False(t, cfg.Logger.LogDBQueries)
 		assert.Equal(t, "https://api.gameap.com", cfg.GlobalAPI.URL)
+	})
+
+	t.Run("database_connect_timeout_override", func(t *testing.T) {
+		t.Setenv("DATABASE_URL", "mysql://localhost/test")
+		t.Setenv("AUTH_SECRET", "test-secret")
+		t.Setenv("DATABASE_CONNECT_TIMEOUT", "5s")
+
+		cfg, err := LoadConfig()
+		require.NoError(t, err)
+
+		assert.Equal(t, 5*time.Second, cfg.DatabaseConnectTimeout)
 	})
 
 	t.Run("default_archive_values", func(t *testing.T) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Startup now retries database connections when the database is temporarily unavailable.
  * Added configurable connection retry timeout via `DATABASE_CONNECT_TIMEOUT`, defaulting to 30 seconds.
  * Retries use progressive delays and stop when the timeout expires or startup is cancelled.

* **Bug Fixes**
  * Prevents startup from failing after a single transient database connection error.

* **Documentation**
  * Documented the new setting, default value, and configuration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->