### PR TITLE
fix grpc nat

### DIFF
--- a/internal/api/nodes/enrollsetup/handler.go
+++ b/internal/api/nodes/enrollsetup/handler.go
@@ -2,6 +2,7 @@ package enrollsetup
 
 import (
 	"fmt"
+	"log/slog"
 	"net/http"
 	"strings"
 
@@ -13,12 +14,13 @@ import (
 )
 
 type Handler struct {
-	enrollmentSvc *enrollment.Service
-	responder     base.Responder
-	grpcExtHost   string
-	grpcPort      uint16
-	grpcExtPort   uint16
-	panelHost     string
+	enrollmentSvc   *enrollment.Service
+	responder       base.Responder
+	grpcExtHost     string
+	grpcPort        uint16
+	grpcExtPort     uint16
+	panelHost       string
+	certHostCovered func(host string) bool
 }
 
 func NewHandler(
@@ -28,14 +30,16 @@ func NewHandler(
 	grpcExtHost string,
 	grpcPort uint16,
 	grpcExtPort uint16,
+	certHostCovered func(host string) bool,
 ) *Handler {
 	return &Handler{
-		enrollmentSvc: enrollmentSvc,
-		responder:     responder,
-		panelHost:     panelHost,
-		grpcExtHost:   grpcExtHost,
-		grpcPort:      grpcPort,
-		grpcExtPort:   grpcExtPort,
+		enrollmentSvc:   enrollmentSvc,
+		responder:       responder,
+		panelHost:       panelHost,
+		grpcExtHost:     grpcExtHost,
+		grpcPort:        grpcPort,
+		grpcExtPort:     grpcExtPort,
+		certHostCovered: certHostCovered,
 	}
 }
 
@@ -80,6 +84,15 @@ func (h *Handler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	grpcPort := h.grpcPort
 	if h.grpcExtPort > 0 {
 		grpcPort = h.grpcExtPort
+	}
+
+	if h.certHostCovered != nil && !h.certHostCovered(grpcHost) {
+		slog.WarnContext(ctx, "resolved gRPC connect host is not covered by the panel gRPC TLS certificate; "+
+			"daemons will fail TLS verification when connecting via this address. "+
+			"Set GRPC_EXTERNAL_HOST to a stable address and restart the panel "+
+			"(its gRPC certificate is regenerated automatically)",
+			slog.String("grpc_host", grpcHost),
+		)
 	}
 
 	connectURL := enrollment.FormatConnectURL(grpcHost, grpcPort, key)

--- a/internal/api/nodes/enrollsetup/handler_test.go
+++ b/internal/api/nodes/enrollsetup/handler_test.go
@@ -233,6 +233,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 				tt.grpcExtHost,
 				tt.grpcPort,
 				tt.grpcExtPort,
+				nil,
 			)
 
 			path := "/nodes/setup/" + tt.key
@@ -358,6 +359,7 @@ func TestHandler_ServeHTTP_ShellInjectionSafety(t *testing.T) {
 				"", // grpcExtHost unset so the header-derived host is used
 				31718,
 				0,
+				nil,
 			)
 
 			q := url.Values{}
@@ -401,7 +403,7 @@ func TestHandler_ServeHTTP_ShellInjectionSafety(t *testing.T) {
 
 func TestHandler_GRPCDisabled(t *testing.T) {
 	responder := api.NewResponder()
-	handler := NewHandler(nil, responder, "", "", 0, 0)
+	handler := NewHandler(nil, responder, "", "", 0, 0, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/nodes/setup/somekey", nil)
 	req = mux.SetURLVars(req, map[string]string{"key": "somekey"})
@@ -410,4 +412,31 @@ func TestHandler_GRPCDisabled(t *testing.T) {
 	handler.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+}
+
+// The uncovered-host warning is log-only for this endpoint: the generated
+// script must stay byte-identical so existing installs are not disturbed.
+func TestHandler_ServeHTTP_uncoveredHostKeepsScriptUnchanged(t *testing.T) {
+	const key = "AbCdEfGh1234567890AbCdEfGh123456"
+
+	buildScript := func(certHostCovered func(string) bool) string {
+		keyManager := setupKeyManager(t, key)
+		enrollSvc := enrollment.NewService(keyManager, nil, nil, nil)
+		handler := NewHandler(enrollSvc, api.NewResponder(), "panel.example.com", "", 31718, 0, certHostCovered)
+
+		req := httptest.NewRequest(http.MethodGet, "/nodes/setup/"+key, nil)
+		req = mux.SetURLVars(req, map[string]string{"key": key})
+		w := httptest.NewRecorder()
+
+		handler.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code)
+
+		return w.Body.String()
+	}
+
+	covered := buildScript(func(string) bool { return true })
+	uncovered := buildScript(func(string) bool { return false })
+
+	assert.Equal(t, covered, uncovered)
+	assert.Contains(t, uncovered, "grpc://panel.example.com:31718/"+key)
 }

--- a/internal/api/nodes/nodesetup/handler.go
+++ b/internal/api/nodes/nodesetup/handler.go
@@ -1,6 +1,7 @@
 package nodesetup
 
 import (
+	"log/slog"
 	"net/http"
 	"strings"
 
@@ -12,12 +13,13 @@ import (
 )
 
 type Handler struct {
-	responder     base.Responder
-	panelHost     string
-	enrollmentSvc *enrollment.Service
-	grpcPort      uint16
-	grpcExtHost   string
-	grpcExtPort   uint16
+	responder       base.Responder
+	panelHost       string
+	enrollmentSvc   *enrollment.Service
+	grpcPort        uint16
+	grpcExtHost     string
+	grpcExtPort     uint16
+	certHostCovered func(host string) bool
 }
 
 func NewHandler(
@@ -27,14 +29,16 @@ func NewHandler(
 	grpcPort uint16,
 	grpcExtHost string,
 	grpcExtPort uint16,
+	certHostCovered func(host string) bool,
 ) *Handler {
 	return &Handler{
-		responder:     responder,
-		panelHost:     panelHost,
-		enrollmentSvc: enrollmentSvc,
-		grpcPort:      grpcPort,
-		grpcExtHost:   grpcExtHost,
-		grpcExtPort:   grpcExtPort,
+		responder:       responder,
+		panelHost:       panelHost,
+		enrollmentSvc:   enrollmentSvc,
+		grpcPort:        grpcPort,
+		grpcExtHost:     grpcExtHost,
+		grpcExtPort:     grpcExtPort,
+		certHostCovered: certHostCovered,
 	}
 }
 
@@ -70,6 +74,21 @@ func (h *Handler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	linuxCmd := "bash <(curl -s '" + setupLink + "')"
 	windowsCmd := "gameapctl daemon install --connect=" + connectURL
 
+	var warnings []string
+	if h.certHostCovered != nil && !h.certHostCovered(grpcHost) {
+		slog.WarnContext(ctx, "resolved gRPC connect host is not covered by the panel gRPC TLS certificate; "+
+			"daemons will fail TLS verification when connecting via this address. "+
+			"Set GRPC_EXTERNAL_HOST to a stable address and restart the panel "+
+			"(its gRPC certificate is regenerated automatically)",
+			slog.String("grpc_host", grpcHost),
+		)
+		warnings = append(warnings,
+			"gRPC connect host \""+grpcHost+"\" is not covered by the panel gRPC TLS certificate. "+
+				"Daemons will fail TLS verification when connecting via this address. "+
+				"Set GRPC_EXTERNAL_HOST in the panel configuration and restart the panel "+
+				"to regenerate the certificate.")
+	}
+
 	h.responder.Write(ctx, rw, setupResponse{
 		Link:        setupLink,
 		Token:       setupKey,
@@ -79,6 +98,7 @@ func (h *Handler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		LinuxCmd:    linuxCmd,
 		WindowsCmd:  windowsCmd,
 		SetupLink:   setupLink,
+		Warnings:    warnings,
 	})
 }
 

--- a/internal/api/nodes/nodesetup/handler_test.go
+++ b/internal/api/nodes/nodesetup/handler_test.go
@@ -83,12 +83,13 @@ func (r *fakeResponder) lastResult() any {
 	return r.lastSuccess
 }
 
-// authedRequest returns a request whose context carries an authenticated
-// Session, mirroring what the auth middleware would inject in production.
-func authedRequest(t *testing.T, method, url string) *http.Request {
+// authedRequest returns a GET /api/nodes/setup request whose context carries
+// an authenticated Session, mirroring what the auth middleware would inject
+// in production.
+func authedRequest(t *testing.T) *http.Request {
 	t.Helper()
 
-	req := httptest.NewRequest(method, url, nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/nodes/setup", nil)
 	req = req.WithContext(auth.ContextWithSession(req.Context(), &auth.Session{
 		User: &domain.User{ID: 1},
 	}))
@@ -139,7 +140,7 @@ func TestHandler_ServeHTTP_unauthenticated_returns401(t *testing.T) {
 	c := cache.NewInMemory()
 	svc := newEnrollmentService(t, c)
 	responder := &fakeResponder{}
-	h := NewHandler(responder, "panel.example.com", svc, 31718, "", 0)
+	h := NewHandler(responder, "panel.example.com", svc, 31718, "", 0, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/nodes/setup", nil)
 	rec := httptest.NewRecorder()
@@ -167,9 +168,9 @@ func TestHandler_ServeHTTP_keyManagerError_propagates(t *testing.T) {
 	// ARRANGE
 	svc := newEnrollmentService(t, &failingCache{setErr: errCacheUnavailable})
 	responder := &fakeResponder{}
-	h := NewHandler(responder, "panel.example.com", svc, 31718, "", 0)
+	h := NewHandler(responder, "panel.example.com", svc, 31718, "", 0, nil)
 
-	req := authedRequest(t, http.MethodGet, "/api/nodes/setup")
+	req := authedRequest(t)
 	rec := httptest.NewRecorder()
 
 	// ACT
@@ -190,9 +191,9 @@ func TestHandler_ServeHTTP_success_writesResponse(t *testing.T) {
 	c := cache.NewInMemory()
 	svc := newEnrollmentService(t, c)
 	responder := &fakeResponder{}
-	h := NewHandler(responder, "panel.example.com", svc, 31718, "", 0)
+	h := NewHandler(responder, "panel.example.com", svc, 31718, "", 0, nil)
 
-	req := authedRequest(t, http.MethodGet, "/api/nodes/setup")
+	req := authedRequest(t)
 	rec := httptest.NewRecorder()
 
 	// ACT
@@ -249,9 +250,9 @@ func TestHandler_ServeHTTP_usesGRPCExtPort_whenSet(t *testing.T) {
 	// ARRANGE
 	svc := newEnrollmentService(t, nil)
 	responder := &fakeResponder{}
-	h := NewHandler(responder, "panel.example.com", svc, 31718, "", 9090)
+	h := NewHandler(responder, "panel.example.com", svc, 31718, "", 9090, nil)
 
-	req := authedRequest(t, http.MethodGet, "/api/nodes/setup")
+	req := authedRequest(t)
 	rec := httptest.NewRecorder()
 
 	// ACT
@@ -265,6 +266,49 @@ func TestHandler_ServeHTTP_usesGRPCExtPort_whenSet(t *testing.T) {
 		"a non-zero grpcExtPort must take precedence over grpcPort")
 	assert.NotContains(t, resp.ConnectURL, ":31718/",
 		"the in-cluster grpcPort must not appear when extPort overrides it")
+}
+
+func TestHandler_ServeHTTP_warnsWhenHostNotCoveredByCert(t *testing.T) {
+	// ARRANGE
+	svc := newEnrollmentService(t, nil)
+	responder := &fakeResponder{}
+	h := NewHandler(responder, "panel.example.com", svc, 31718, "", 0,
+		func(string) bool { return false })
+
+	req := authedRequest(t)
+	rec := httptest.NewRecorder()
+
+	// ACT
+	h.ServeHTTP(rec, req)
+
+	// ASSERT
+	require.Equal(t, 1, responder.successCalls())
+	resp, ok := responder.lastResult().(setupResponse)
+	require.True(t, ok)
+
+	require.Len(t, resp.Warnings, 1)
+	assert.Contains(t, resp.Warnings[0], "panel.example.com")
+	assert.Contains(t, resp.Warnings[0], "GRPC_EXTERNAL_HOST")
+}
+
+func TestHandler_ServeHTTP_noWarningsWhenHostCovered(t *testing.T) {
+	// ARRANGE
+	svc := newEnrollmentService(t, nil)
+	responder := &fakeResponder{}
+	h := NewHandler(responder, "panel.example.com", svc, 31718, "", 0,
+		func(string) bool { return true })
+
+	req := authedRequest(t)
+	rec := httptest.NewRecorder()
+
+	// ACT
+	h.ServeHTTP(rec, req)
+
+	// ASSERT
+	require.Equal(t, 1, responder.successCalls())
+	resp, ok := responder.lastResult().(setupResponse)
+	require.True(t, ok)
+	assert.Empty(t, resp.Warnings)
 }
 
 // -----------------------------------------------------------------------------
@@ -332,7 +376,7 @@ func TestHandler_resolveGRPCHost(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// ARRANGE
-			h := NewHandler(&fakeResponder{}, tt.panelHost, nil, 31718, tt.grpcExtHost, 0)
+			h := NewHandler(&fakeResponder{}, tt.panelHost, nil, 31718, tt.grpcExtHost, 0, nil)
 			req := httptest.NewRequest(http.MethodGet, "/api/nodes/setup", nil)
 			if tt.forwardedHost != "" {
 				req.Header.Set("X-Forwarded-Host", tt.forwardedHost)
@@ -400,7 +444,7 @@ func TestHandler_detectBaseURL(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// ARRANGE
-			h := NewHandler(&fakeResponder{}, tt.panelHost, nil, 31718, "", 0)
+			h := NewHandler(&fakeResponder{}, tt.panelHost, nil, 31718, "", 0, nil)
 			req := httptest.NewRequest(http.MethodGet, "/api/nodes/setup", nil)
 			if tt.forwardedHost != "" {
 				req.Header.Set("X-Forwarded-Host", tt.forwardedHost)
@@ -434,7 +478,7 @@ func TestNewHandler_assemblesDependencies(t *testing.T) {
 	svc := newEnrollmentService(t, nil)
 
 	// ACT
-	h := NewHandler(responder, "panel.example.com", svc, 31718, "grpc.example.com", 9090)
+	h := NewHandler(responder, "panel.example.com", svc, 31718, "grpc.example.com", 9090, nil)
 
 	// ASSERT
 	require.NotNil(t, h)

--- a/internal/api/nodes/nodesetup/response.go
+++ b/internal/api/nodes/nodesetup/response.go
@@ -10,4 +10,6 @@ type setupResponse struct {
 	LinuxCmd    string `json:"linux_cmd,omitempty"`
 	WindowsCmd  string `json:"windows_cmd,omitempty"`
 	SetupLink   string `json:"setup_link,omitempty"`
+
+	Warnings []string `json:"warnings,omitempty"`
 }

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -238,6 +238,7 @@ type container interface {
 	GRPCPort() uint16
 	GRPCExternalHost() string
 	GRPCExternalPort() uint16
+	GRPCCertHostCovered(host string) bool
 	WSHub() *ws.Hub
 	SessionRegistry() *session.Registry
 	CommandHandler() *grpchandlers.CommandHandler
@@ -1367,6 +1368,7 @@ func apiRoutes(c container, router *mux.Router) *mux.Router {
 				c.GRPCPort(),
 				c.GRPCExternalHost(),
 				c.GRPCExternalPort(),
+				c.GRPCCertHostCovered,
 			),
 			AdminOnly: true,
 		},
@@ -1381,6 +1383,7 @@ func apiRoutes(c container, router *mux.Router) *mux.Router {
 				c.GRPCPort(),
 				c.GRPCExternalHost(),
 				c.GRPCExternalPort(),
+				c.GRPCCertHostCovered,
 			),
 			AdminOnly: true,
 		},
@@ -2148,6 +2151,7 @@ func nodeEnrollRoutes(c container, router *mux.Router) *mux.Router {
 				c.GRPCExternalHost(),
 				c.GRPCPort(),
 				c.GRPCExternalPort(),
+				c.GRPCCertHostCovered,
 			),
 		},
 	}

--- a/internal/application/container.go
+++ b/internal/application/container.go
@@ -245,6 +245,7 @@ type Container struct {
 	metricsHub          metrics.Hub
 	taskReaper          *taskreaper.Reaper
 	grpcServer          *grpc.Server
+	grpcServerCertLeaf  *x509.Certificate
 	multiplexedServer   *MultiplexedServer
 
 	// Shutdown
@@ -1646,6 +1647,17 @@ func (c *Container) GRPCExternalPort() uint16 {
 	return c.config.GRPC.ExternalPort
 }
 
+// GRPCCertHostCovered reports whether the gRPC TLS server certificate of this
+// instance covers host. Returns true when gRPC TLS is disabled or the
+// certificate has not been loaded: there is nothing to warn about then.
+func (c *Container) GRPCCertHostCovered(host string) bool {
+	if c.grpcServerCertLeaf == nil {
+		return true
+	}
+
+	return c.grpcServerCertLeaf.VerifyHostname(host) == nil
+}
+
 func (c *Container) GlobalAPIService() *services.GlobalAPIService {
 	if c.globalAPIService == nil {
 		c.globalAPIService = c.createGlobalAPIService()
@@ -2473,6 +2485,7 @@ func (c *Container) buildGRPCTLSConfig() (*tls.Config, error) {
 	}
 
 	if leaf, parseErr := x509.ParseCertificate(cert.Certificate[0]); parseErr == nil {
+		c.grpcServerCertLeaf = leaf
 		slog.Info("gRPC TLS server certificate loaded",
 			"common_name", leaf.Subject.CommonName,
 			"dns_names", leaf.DNSNames,

--- a/internal/application/tls_helpers.go
+++ b/internal/application/tls_helpers.go
@@ -85,10 +85,11 @@ func resolveGRPCCertSANs(httpHost, httpBindIP, externalHost string) []sanSource 
 		}
 	}
 
-	if httpHost == "" || httpHost == "0.0.0.0" {
-		for _, s := range detectInterfaceSANs() {
-			addEntry(s)
-		}
+	// Interface IPs are always included so that a daemon on the same machine can
+	// reach the panel by a local address even when HTTP_HOST points elsewhere
+	// (e.g. a public address of a NAT in front of this machine).
+	for _, s := range detectInterfaceSANs() {
+		addEntry(s)
 	}
 
 	addEntry(sanSource{ip: net.IPv4(127, 0, 0, 1), from: "fallback"})

--- a/internal/application/tls_helpers_test.go
+++ b/internal/application/tls_helpers_test.go
@@ -83,17 +83,36 @@ func TestResolveGRPCCertSANs(t *testing.T) {
 			},
 		},
 		{
-			name:         "specific_http_host_skips_auto_detect",
+			name:         "specific_http_host_appends_auto_detect",
 			httpHost:     "192.168.0.1",
 			httpBindIP:   "",
 			externalHost: "",
 			stubAuto: []sanSource{
 				{ip: net.ParseIP("10.0.0.99"), from: "auto:eth9"},
 			},
-			wantIPs: []string{"192.168.0.1", "127.0.0.1"},
+			wantIPs: []string{"192.168.0.1", "10.0.0.99", "127.0.0.1"},
 			wantDNS: []string{"localhost"},
 			wantSources: map[string]string{
 				"ip:192.168.0.1": "config:HTTP_HOST",
+				"ip:10.0.0.99":   "auto:eth9",
+				"ip:127.0.0.1":   "fallback",
+				"dns:localhost":  "fallback",
+			},
+		},
+		{
+			name:         "nat_local_http_host_keeps_config_source_and_appends_other_interfaces",
+			httpHost:     "10.73.43.20",
+			httpBindIP:   "",
+			externalHost: "",
+			stubAuto: []sanSource{
+				{ip: net.ParseIP("10.73.43.20"), from: "auto:eth0"},
+				{ip: net.ParseIP("192.168.1.5"), from: "auto:eth1"},
+			},
+			wantIPs: []string{"10.73.43.20", "192.168.1.5", "127.0.0.1"},
+			wantDNS: []string{"localhost"},
+			wantSources: map[string]string{
+				"ip:10.73.43.20": "config:HTTP_HOST",
+				"ip:192.168.1.5": "auto:eth1",
 				"ip:127.0.0.1":   "fallback",
 				"dns:localhost":  "fallback",
 			},

--- a/openapi/schemas/responses/NodeSetupResponse.yaml
+++ b/openapi/schemas/responses/NodeSetupResponse.yaml
@@ -31,6 +31,13 @@ properties:
   setup_link:
     type: string
     description: Setup script URL for the gRPC enrollment flow; present when grpc_enabled=true
+  warnings:
+    type: array
+    items:
+      type: string
+    description: |
+      Configuration warnings detected while building the setup data, e.g. the
+      gRPC connect host is not covered by the panel gRPC TLS certificate.
 required:
   - host
   - grpc_enabled

--- a/pkg/testcontainer/inmemory.go
+++ b/pkg/testcontainer/inmemory.go
@@ -255,6 +255,8 @@ func (c *InmemoryContainer) GRPCPort() uint16         { return 31718 }
 func (c *InmemoryContainer) GRPCExternalHost() string { return "" }
 func (c *InmemoryContainer) GRPCExternalPort() uint16 { return 0 }
 
+func (c *InmemoryContainer) GRPCCertHostCovered(_ string) bool { return true }
+
 type nopUploader struct{}
 
 func (nopUploader) UploadStreamPrepared(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Node setup responses now include warnings when the configured gRPC host is not covered by the server’s TLS certificate.
  * Enrollment and setup flows validate certificate host coverage and clearly surface configuration issues.
  * TLS certificates now include eligible network-interface addresses more consistently.

* **Bug Fixes**
  * Preserved generated enrollment scripts when certificate host coverage differs, while retaining the expected connection URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->