### PR TITLE
Widen port columns

### DIFF
--- a/internal/api/servers/postserver/handler_test.go
+++ b/internal/api/servers/postserver/handler_test.go
@@ -21,10 +21,13 @@ import (
 
 func TestHandler_ServeHTTP(t *testing.T) {
 	tests := []struct {
-		name           string
-		requestBody    string
-		expectedStatus int
-		wantError      string
+		name               string
+		requestBody        string
+		expectedStatus     int
+		wantError          string
+		expectedServerPort int
+		expectedQueryPort  int
+		expectedRconPort   int
 	}{
 		{
 			name: "valid server creation",
@@ -66,7 +69,10 @@ func TestHandler_ServeHTTP(t *testing.T) {
 				"query_port": 47016,
 				"rcon_port": 65535
 			}`,
-			expectedStatus: http.StatusCreated,
+			expectedStatus:     http.StatusCreated,
+			expectedServerPort: 47015,
+			expectedQueryPort:  47016,
+			expectedRconPort:   65535,
 		},
 		{
 			name: "missing name",
@@ -578,6 +584,8 @@ func TestHandler_ServeHTTP(t *testing.T) {
 				// Verify response contains expected fields
 				assert.Equal(t, "success", response.Message)
 				assert.NotEmpty(t, response.Result.ServerID)
+
+				assertSavedServerPorts(t, servers[0], tt.expectedServerPort, tt.expectedQueryPort, tt.expectedRconPort)
 			}
 		})
 	}
@@ -1556,6 +1564,24 @@ func TestHandler_TaskDispatcher_Success(t *testing.T) {
 	tasks, err := daemonTaskRepo.FindAll(context.Background(), nil, nil)
 	require.NoError(t, err)
 	assert.Empty(t, tasks, "dispatcher path must bypass the repository")
+}
+
+func assertSavedServerPorts(t *testing.T, server domain.Server, serverPort, queryPort, rconPort int) {
+	t.Helper()
+
+	if serverPort != 0 {
+		assert.Equal(t, serverPort, server.ServerPort)
+	}
+
+	if queryPort != 0 {
+		require.NotNil(t, server.QueryPort)
+		assert.Equal(t, queryPort, *server.QueryPort)
+	}
+
+	if rconPort != 0 {
+		require.NotNil(t, server.RconPort)
+		assert.Equal(t, rconPort, *server.RconPort)
+	}
 }
 
 const stubDispatchedTaskID = 42

--- a/internal/api/servers/postserver/handler_test.go
+++ b/internal/api/servers/postserver/handler_test.go
@@ -55,6 +55,20 @@ func TestHandler_ServeHTTP(t *testing.T) {
 			expectedStatus: http.StatusCreated,
 		},
 		{
+			name: "valid_server_creation_with_high_ports",
+			requestBody: `{
+				"name": "High Port Server",
+				"game_id": "cstrike",
+				"ds_id": 1,
+				"game_mod_id": 1,
+				"server_ip": "192.168.1.100",
+				"server_port": 47015,
+				"query_port": 47016,
+				"rcon_port": 65535
+			}`,
+			expectedStatus: http.StatusCreated,
+		},
+		{
 			name: "missing name",
 			requestBody: `{
 				"game_id": "cstrike",

--- a/internal/repositories/testing/nodes_suite.go
+++ b/internal/repositories/testing/nodes_suite.go
@@ -170,6 +170,31 @@ func (s *NodeRepositorySuite) TestNodeRepositorySave() {
 		assert.Len(t, results[0].IPs, 2)
 	})
 
+	s.T().Run("insert_node_with_high_gdaemon_port", func(t *testing.T) {
+		node := &domain.Node{
+			Enabled:             true,
+			Name:                "High Port Node",
+			OS:                  domain.NodeOSLinux,
+			Location:            "EU-North",
+			IPs:                 domain.IPList{"192.168.3.1"},
+			WorkPath:            "/srv/gameap",
+			GdaemonHost:         "highport.example.com",
+			GdaemonPort:         40000,
+			GdaemonAPIKey:       "test-api-key-3",
+			GdaemonServerCert:   "cert-data-3",
+			ClientCertificateID: 3,
+			PreferInstallMethod: domain.NodePreferInstallMethodAuto,
+		}
+
+		err := s.repo.Save(ctx, node)
+		require.NoError(t, err)
+
+		nodes, err := s.repo.Find(ctx, filters.FindNodeByIDs(node.ID), nil, nil)
+		require.NoError(t, err)
+		require.Len(t, nodes, 1)
+		assert.Equal(t, 40000, nodes[0].GdaemonPort)
+	})
+
 	s.T().Run("auto_set_timestamps", func(t *testing.T) {
 		node := &domain.Node{
 			Name:                "Timestamp Node",

--- a/internal/repositories/testing/servers_suite.go
+++ b/internal/repositories/testing/servers_suite.go
@@ -87,6 +87,34 @@ func (s *ServerRepositorySuite) TestServerRepositorySave() {
 		assert.Equal(t, domain.ServerInstalledStatusInstalled, server.Installed)
 		assert.True(t, server.UpdatedAt.After(*originalUpdatedAt))
 	})
+
+	s.T().Run("insert_server_with_high_ports", func(t *testing.T) {
+		server := &domain.Server{
+			UID:        uuid.New(),
+			UUIDShort:  "test3",
+			Enabled:    true,
+			Installed:  domain.ServerInstalledStatusInstalled,
+			Name:       "High Port Server",
+			GameID:     "csgo",
+			DSID:       1,
+			ServerIP:   "127.0.0.1",
+			ServerPort: 47015,
+			QueryPort:  new(47016),
+			RconPort:   new(65535),
+		}
+
+		err := s.repo.Save(ctx, server)
+		require.NoError(t, err)
+
+		results, err := s.repo.Find(ctx, &filters.FindServer{IDs: []uint{server.ID}}, nil, nil)
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		assert.Equal(t, 47015, results[0].ServerPort)
+		require.NotNil(t, results[0].QueryPort)
+		assert.Equal(t, 47016, *results[0].QueryPort)
+		require.NotNil(t, results[0].RconPort)
+		assert.Equal(t, 65535, *results[0].RconPort)
+	})
 }
 
 func (s *ServerRepositorySuite) TestServerRepositoryDelete() {

--- a/migrations/mysql/014_widen_port_columns.sql
+++ b/migrations/mysql/014_widen_port_columns.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- No-op: MySQL declares dedicated_servers.gdaemon_port and the servers port
+-- columns (server_port, query_port, rcon_port) as int(10) unsigned, which
+-- already holds the full 1..65535 port range. This migration only reserves
+-- version 014 to keep the numbering aligned with the PostgreSQL migration set,
+-- where these columns are widened from SMALLINT to INTEGER.
+
+-- +goose Down
+-- No-op: see the Up section.

--- a/migrations/postgres/014_widen_port_columns.sql
+++ b/migrations/postgres/014_widen_port_columns.sql
@@ -1,0 +1,13 @@
+-- +goose Up
+ALTER TABLE dedicated_servers ALTER COLUMN gdaemon_port TYPE INTEGER;
+ALTER TABLE servers
+    ALTER COLUMN server_port TYPE INTEGER,
+    ALTER COLUMN query_port TYPE INTEGER,
+    ALTER COLUMN rcon_port TYPE INTEGER;
+
+-- +goose Down
+ALTER TABLE dedicated_servers ALTER COLUMN gdaemon_port TYPE SMALLINT;
+ALTER TABLE servers
+    ALTER COLUMN server_port TYPE SMALLINT,
+    ALTER COLUMN query_port TYPE SMALLINT,
+    ALTER COLUMN rcon_port TYPE SMALLINT;

--- a/migrations/sqlite/014_widen_port_columns.sql
+++ b/migrations/sqlite/014_widen_port_columns.sql
@@ -1,0 +1,10 @@
+-- +goose Up
+-- No-op: SQLite stores INTEGER values using a variable-length encoding of up to
+-- 8 bytes (64-bit signed), so dedicated_servers.gdaemon_port and the servers
+-- port columns (server_port, query_port, rcon_port) already hold the full
+-- 1..65535 port range without any schema change. This migration only reserves
+-- version 014 to keep the numbering aligned with the PostgreSQL migration set,
+-- where these columns are widened from SMALLINT to INTEGER.
+
+-- +goose Down
+-- No-op: see the Up section.

--- a/openapi/schemas/requests/CreateNodeRequest.yaml
+++ b/openapi/schemas/requests/CreateNodeRequest.yaml
@@ -42,7 +42,9 @@ properties:
     example: "192.168.1.100"
   gdaemon_port:
     type: integer
-    description: GDaemon port
+    minimum: 1
+    maximum: 65535
+    description: GDaemon port (1-65535)
     example: 31717
   client_certificate_id:
     type: integer

--- a/openapi/schemas/requests/CreateServerRequest.yaml
+++ b/openapi/schemas/requests/CreateServerRequest.yaml
@@ -29,18 +29,24 @@ properties:
   server_port:
     oneOf:
       - type: integer
+        minimum: 1
+        maximum: 65535
       - type: string
     description: Server port (1-65535)
     example: 27015
   query_port:
     oneOf:
       - type: integer
+        minimum: 1
+        maximum: 65535
       - type: string
     description: Query port (1-65535), optional
     example: 27016
   rcon_port:
     oneOf:
       - type: integer
+        minimum: 1
+        maximum: 65535
       - type: string
     description: RCON port (1-65535), optional
     example: 27017

--- a/openapi/schemas/requests/CreateServerRequest.yaml
+++ b/openapi/schemas/requests/CreateServerRequest.yaml
@@ -32,6 +32,7 @@ properties:
         minimum: 1
         maximum: 65535
       - type: string
+        pattern: '^([1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$'
     description: Server port (1-65535)
     example: 27015
   query_port:
@@ -40,6 +41,7 @@ properties:
         minimum: 1
         maximum: 65535
       - type: string
+        pattern: '^([1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$'
     description: Query port (1-65535), optional
     example: 27016
   rcon_port:
@@ -48,6 +50,7 @@ properties:
         minimum: 1
         maximum: 65535
       - type: string
+        pattern: '^([1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$'
     description: RCON port (1-65535), optional
     example: 27017
   rcon:

--- a/openapi/schemas/requests/UpdateNodeRequest.yaml
+++ b/openapi/schemas/requests/UpdateNodeRequest.yaml
@@ -45,7 +45,9 @@ properties:
     description: GDaemon hostname
   gdaemon_port:
     type: integer
-    description: GDaemon port
+    minimum: 1
+    maximum: 65535
+    description: GDaemon port (1-65535)
   client_certificate_id:
     type: integer
     description: Client certificate ID

--- a/openapi/schemas/requests/UpdateServerRequest.yaml
+++ b/openapi/schemas/requests/UpdateServerRequest.yaml
@@ -44,6 +44,7 @@ properties:
         minimum: 1
         maximum: 65535
       - type: string
+        pattern: '^([1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$'
     description: Server port (1-65535)
     example: 27015
   query_port:
@@ -52,6 +53,7 @@ properties:
         minimum: 1
         maximum: 65535
       - type: string
+        pattern: '^([1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$'
     description: Query port (1-65535)
     example: 27016
   rcon_port:
@@ -60,6 +62,7 @@ properties:
         minimum: 1
         maximum: 65535
       - type: string
+        pattern: '^([1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$'
     description: RCON port (1-65535)
     example: 27017
   rcon:

--- a/openapi/schemas/requests/UpdateServerRequest.yaml
+++ b/openapi/schemas/requests/UpdateServerRequest.yaml
@@ -41,20 +41,26 @@ properties:
   server_port:
     oneOf:
       - type: integer
+        minimum: 1
+        maximum: 65535
       - type: string
-    description: Server port
+    description: Server port (1-65535)
     example: 27015
   query_port:
     oneOf:
       - type: integer
+        minimum: 1
+        maximum: 65535
       - type: string
-    description: Query port
+    description: Query port (1-65535)
     example: 27016
   rcon_port:
     oneOf:
       - type: integer
+        minimum: 1
+        maximum: 65535
       - type: string
-    description: RCON port
+    description: RCON port (1-65535)
     example: 27017
   rcon:
     type: string


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Expanded server and node port support to the full valid range of 1–65,535.
  - Preserved high port values when creating, updating, saving, and retrieving servers and nodes.
  - Added support for maximum RCON port values.

- **Documentation**
  - Updated API validation rules and descriptions to document accepted port ranges.

- **Tests**
  - Added coverage for high and maximum port values across API and persistence workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->