### PR TITLE
fix file manager archive download

### DIFF
--- a/internal/api/filemanager/downloadarchive/handler.go
+++ b/internal/api/filemanager/downloadarchive/handler.go
@@ -217,20 +217,41 @@ func (h *Handler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	rw.Header().Set("X-Archive-Skipped-Count", strconv.Itoa(len(manifest.Skipped)))
 	rw.Header().Set("Cache-Control", "no-store")
 
-	_, err = h.archiver.WriteArchive(ctx, rw, node, manifest, archiver.Options{
+	tracked := &responseTracker{ResponseWriter: rw}
+
+	_, err = h.archiver.WriteArchive(ctx, tracked, node, manifest, archiver.Options{
 		CompressLevel: compressLevel,
 	})
-	if err == nil {
-		return
+	if err != nil {
+		h.handleWriteError(ctx, rw, tracked.started, server.ID, err)
 	}
+}
 
+func (h *Handler) handleWriteError(
+	ctx context.Context,
+	rw http.ResponseWriter,
+	responseStarted bool,
+	serverID uint,
+	err error,
+) {
 	if ctx.Err() != nil {
 		slog.InfoContext(
 			ctx,
 			"archive download cancelled by client",
 			slog.String("error", err.Error()),
-			slog.Uint64("server_id", uint64(server.ID)),
+			slog.Uint64("server_id", uint64(serverID)),
 		)
+
+		return
+	}
+
+	// The archiver buffers its first bytes, so a failure on the first entry usually happens
+	// before anything reached net/http and can still be reported as a regular error response.
+	if !responseStarted {
+		for _, name := range archiveHeaders {
+			rw.Header().Del(name)
+		}
+		h.responder.WriteError(ctx, rw, errors.WithMessage(err, "write archive"))
 
 		return
 	}
@@ -239,13 +260,49 @@ func (h *Handler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		ctx,
 		"failed to write archive",
 		slog.String("error", err.Error()),
-		slog.Uint64("server_id", uint64(server.ID)),
+		slog.Uint64("server_id", uint64(serverID)),
 	)
 
 	// The 200 and part of the body are already on the wire, so the only way to tell the client
 	// the archive is unusable is to abort the response (truncated chunked body / RST_STREAM)
 	// instead of ending it cleanly and letting the browser keep a truncated zip as complete.
 	panic(http.ErrAbortHandler)
+}
+
+var archiveHeaders = []string{
+	"Content-Disposition",
+	"X-Archive-Total-Bytes",
+	"X-Archive-Total-Files",
+	"X-Archive-Skipped-Count",
+}
+
+// responseTracker records whether the status line, headers or any body bytes were already
+// handed to net/http, which decides how a later failure can still be reported.
+type responseTracker struct {
+	http.ResponseWriter
+
+	started bool
+}
+
+func (t *responseTracker) WriteHeader(code int) {
+	t.started = true
+	t.ResponseWriter.WriteHeader(code)
+}
+
+func (t *responseTracker) Write(p []byte) (int, error) {
+	t.started = true
+
+	return t.ResponseWriter.Write(p)
+}
+
+func (t *responseTracker) FlushError() error {
+	t.started = true
+
+	return http.NewResponseController(t.ResponseWriter).Flush()
+}
+
+func (t *responseTracker) Unwrap() http.ResponseWriter {
+	return t.ResponseWriter
 }
 
 func (h *Handler) getNode(ctx context.Context, nodeID uint) (*domain.Node, error) {

--- a/internal/api/filemanager/downloadarchive/handler.go
+++ b/internal/api/filemanager/downloadarchive/handler.go
@@ -220,14 +220,32 @@ func (h *Handler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	_, err = h.archiver.WriteArchive(ctx, rw, node, manifest, archiver.Options{
 		CompressLevel: compressLevel,
 	})
-	if err != nil {
-		slog.ErrorContext(
+	if err == nil {
+		return
+	}
+
+	if ctx.Err() != nil {
+		slog.InfoContext(
 			ctx,
-			"failed to write archive",
+			"archive download cancelled by client",
 			slog.String("error", err.Error()),
 			slog.Uint64("server_id", uint64(server.ID)),
 		)
+
+		return
 	}
+
+	slog.ErrorContext(
+		ctx,
+		"failed to write archive",
+		slog.String("error", err.Error()),
+		slog.Uint64("server_id", uint64(server.ID)),
+	)
+
+	// The 200 and part of the body are already on the wire, so the only way to tell the client
+	// the archive is unusable is to abort the response (truncated chunked body / RST_STREAM)
+	// instead of ending it cleanly and letting the browser keep a truncated zip as complete.
+	panic(http.ErrAbortHandler)
 }
 
 func (h *Handler) getNode(ctx context.Context, nodeID uint) (*domain.Node, error) {

--- a/internal/api/filemanager/downloadarchive/handler_test.go
+++ b/internal/api/filemanager/downloadarchive/handler_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/gameap/gameap/internal/api/middlewares"
+	"github.com/gameap/gameap/internal/daemon"
 	"github.com/gameap/gameap/internal/domain"
 	"github.com/gameap/gameap/internal/filters"
 	"github.com/gameap/gameap/internal/rbac"
@@ -506,6 +507,59 @@ func TestHandler_ServeHTTP(t *testing.T) {
 				assert.Empty(t, w.Body.String())
 				assert.True(t, g.released.Load(), "concurrency slot must be released after a client cancel")
 			},
+		},
+		{
+			name:      "write_failure_before_first_byte_returns_json_error",
+			serverID:  "1",
+			queryDisk: "server",
+			queryPath: "data",
+			setupCtx:  authedCtx,
+			setupRepo: saveServerWithFilesAbility,
+			setupArchiver: func() *stubArchiver {
+				return &stubArchiver{
+					manifest: &archiver.Manifest{
+						RootName:   "data",
+						TotalSize:  10,
+						TotalFiles: 1,
+						Entries:    []archiver.Entry{{RelPath: "data/a.txt", Size: 10}},
+					},
+					writeErr: errDaemonUnavailable,
+				}
+			},
+			setupGuard:     func() *fakeGuard { return &fakeGuard{} },
+			expectedStatus: http.StatusInternalServerError,
+			wantError:      `"status":"error"`,
+			validate: func(t *testing.T, w *httptest.ResponseRecorder, _ *stubArchiver, g *fakeGuard) {
+				t.Helper()
+				assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+				assert.Empty(t, w.Header().Get("Content-Disposition"), "archive headers must not leak into the error")
+				assert.Empty(t, w.Header().Get("X-Archive-Total-Bytes"))
+				assert.Empty(t, w.Header().Get("X-Archive-Total-Files"))
+				assert.Empty(t, w.Header().Get("X-Archive-Skipped-Count"))
+				assert.True(t, g.released.Load(), "concurrency slot must be released")
+			},
+		},
+		{
+			name:      "write_failure_before_first_byte_keeps_daemon_status",
+			serverID:  "1",
+			queryDisk: "server",
+			queryPath: "data",
+			setupCtx:  authedCtx,
+			setupRepo: saveServerWithFilesAbility,
+			setupArchiver: func() *stubArchiver {
+				return &stubArchiver{
+					manifest: &archiver.Manifest{
+						RootName:   "data",
+						TotalSize:  10,
+						TotalFiles: 1,
+						Entries:    []archiver.Entry{{RelPath: "data/a.txt", Size: 10}},
+					},
+					writeErr: daemon.ErrDaemonNotConnected,
+				}
+			},
+			setupGuard:     func() *fakeGuard { return &fakeGuard{} },
+			expectedStatus: http.StatusBadGateway,
+			wantError:      "Bad Gateway",
 		},
 		{
 			name:          "success_compress_zero_produces_store_zip",

--- a/internal/api/filemanager/downloadarchive/handler_test.go
+++ b/internal/api/filemanager/downloadarchive/handler_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gameap/gameap/internal/api/middlewares"
 	"github.com/gameap/gameap/internal/domain"
 	"github.com/gameap/gameap/internal/filters"
 	"github.com/gameap/gameap/internal/rbac"
@@ -114,6 +115,7 @@ type stubArchiver struct {
 	manifestErr   error
 	writeErr      error
 	writeContent  []byte
+	onWrite       func(w io.Writer)
 	writeRecorded *archiver.Manifest
 	recordedOpts  archiver.Options
 }
@@ -129,16 +131,22 @@ func (s *stubArchiver) WriteArchive(
 ) (*archiver.Result, error) {
 	s.recordedOpts = opts
 	s.writeRecorded = m
-	if s.writeErr != nil {
-		return nil, s.writeErr
+	if s.onWrite != nil {
+		s.onWrite(w)
 	}
 	if len(s.writeContent) > 0 {
 		n, err := w.Write(s.writeContent)
 		if err != nil {
 			return nil, err
 		}
+		if s.writeErr != nil {
+			return nil, s.writeErr
+		}
 
 		return &archiver.Result{BytesWritten: uint64(n)}, nil
+	}
+	if s.writeErr != nil {
+		return nil, s.writeErr
 	}
 
 	zw := zip.NewWriter(w)
@@ -165,6 +173,9 @@ func (f *fakeGuard) Acquire(_ context.Context, _ uint) (func(), error) {
 }
 
 func TestHandler_ServeHTTP(t *testing.T) {
+	cancelledDuringWriteCtx, cancelDuringWrite := context.WithCancel(authedCtx())
+	t.Cleanup(cancelDuringWrite)
+
 	tests := []struct {
 		name           string
 		serverID       string
@@ -177,6 +188,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 		setupGuard     func() *fakeGuard
 		limits         Limits
 		expectedStatus int
+		expectAbort    bool
 		wantError      string
 		validate       func(*testing.T, *httptest.ResponseRecorder, *stubArchiver, *fakeGuard)
 	}{
@@ -433,6 +445,68 @@ func TestHandler_ServeHTTP(t *testing.T) {
 			expectedStatus: http.StatusInternalServerError,
 		},
 		{
+			name:      "write_failure_after_headers_aborts_response",
+			serverID:  "1",
+			queryDisk: "server",
+			queryPath: "data",
+			setupCtx:  authedCtx,
+			setupRepo: saveServerWithFilesAbility,
+			setupArchiver: func() *stubArchiver {
+				return &stubArchiver{
+					manifest: &archiver.Manifest{
+						RootName:   "data",
+						TotalSize:  500,
+						TotalFiles: 2,
+						Entries: []archiver.Entry{
+							{RelPath: "data/a.txt", Size: 250},
+							{RelPath: "data/b.txt", Size: 250},
+						},
+					},
+					writeContent: []byte("PK\x03\x04partial-local-header"),
+					writeErr:     errDaemonUnavailable,
+				}
+			},
+			setupGuard:     func() *fakeGuard { return &fakeGuard{} },
+			expectedStatus: http.StatusOK,
+			expectAbort:    true,
+			validate: func(t *testing.T, w *httptest.ResponseRecorder, _ *stubArchiver, g *fakeGuard) {
+				t.Helper()
+				assert.Equal(t, "application/zip", w.Header().Get("Content-Type"))
+				assert.Equal(t, "500", w.Header().Get("X-Archive-Total-Bytes"))
+				assert.Equal(t, "PK\x03\x04partial-local-header", w.Body.String(),
+					"nothing may be appended after the partial archive bytes")
+				assert.True(t, g.released, "concurrency slot must be released while the panic unwinds")
+			},
+		},
+		{
+			name:      "client_cancel_during_write_returns_without_abort",
+			serverID:  "1",
+			queryDisk: "server",
+			queryPath: "data",
+			setupCtx:  func() context.Context { return cancelledDuringWriteCtx },
+			setupRepo: saveServerWithFilesAbility,
+			setupArchiver: func() *stubArchiver {
+				return &stubArchiver{
+					manifest: &archiver.Manifest{
+						RootName:   "data",
+						TotalSize:  10,
+						TotalFiles: 1,
+						Entries:    []archiver.Entry{{RelPath: "data/a.txt", Size: 10}},
+					},
+					onWrite:  func(_ io.Writer) { cancelDuringWrite() },
+					writeErr: context.Canceled,
+				}
+			},
+			setupGuard:     func() *fakeGuard { return &fakeGuard{} },
+			expectedStatus: http.StatusOK,
+			validate: func(t *testing.T, w *httptest.ResponseRecorder, _ *stubArchiver, g *fakeGuard) {
+				t.Helper()
+				assert.Equal(t, "application/zip", w.Header().Get("Content-Type"))
+				assert.Empty(t, w.Body.String())
+				assert.True(t, g.released, "concurrency slot must be released after a client cancel")
+			},
+		},
+		{
 			name:          "success_compress_zero_produces_store_zip",
 			serverID:      "1",
 			queryDisk:     "server",
@@ -637,7 +711,13 @@ func TestHandler_ServeHTTP(t *testing.T) {
 			req = mux.SetURLVars(req, map[string]string{"server": tt.serverID})
 			w := httptest.NewRecorder()
 
-			handler.ServeHTTP(w, req)
+			if tt.expectAbort {
+				require.PanicsWithValue(t, http.ErrAbortHandler, func() {
+					handler.ServeHTTP(w, req)
+				}, "mid-stream failure must abort the response via http.ErrAbortHandler")
+			} else {
+				handler.ServeHTTP(w, req)
+			}
 
 			assert.Equal(t, tt.expectedStatus, w.Code)
 
@@ -650,6 +730,78 @@ func TestHandler_ServeHTTP(t *testing.T) {
 			}
 		})
 	}
+}
+
+// Runs the handler behind a real net/http server (through the recovery middleware, like the
+// router does) and checks the wire-level contract: a mid-stream failure leaves the client with a
+// transport error while reading the body instead of a cleanly terminated, truncated archive.
+func TestHandler_ServeHTTP_WriteFailureTruncatesResponseBody(t *testing.T) {
+	serverRepo := inmemory.NewServerRepository()
+	nodeRepo := inmemory.NewNodeRepository()
+	rbacRepo := inmemory.NewRBACRepository()
+	rbacService := rbac.NewRBAC(services.NewNilTransactionManager(), rbacRepo, 0)
+	responder := api.NewResponder()
+	saveServerWithFilesAbility(t, serverRepo, nodeRepo, rbacRepo)
+
+	partial := bytes.Repeat([]byte("PK-partial-"), 8*1024)
+	arch := &stubArchiver{
+		manifest: &archiver.Manifest{
+			RootName:   "data",
+			TotalSize:  500,
+			TotalFiles: 1,
+			Entries:    []archiver.Entry{{RelPath: "data/a.txt", Size: 500}},
+		},
+		onWrite: func(w io.Writer) {
+			// Push the headers and the first bytes to the client before the failure,
+			// the way the archiver's periodic flush does for a real archive.
+			if _, err := w.Write(partial); err == nil {
+				if rw, ok := w.(http.ResponseWriter); ok {
+					_ = http.NewResponseController(rw).Flush()
+				}
+			}
+		},
+		writeErr: errDaemonUnavailable,
+	}
+	guard := &fakeGuard{}
+	handler := NewHandler(serverRepo, nodeRepo, rbacService, arch, guard, Limits{}, responder)
+
+	router := mux.NewRouter()
+	router.Handle(
+		"/api/file-manager/{server}/download-archive",
+		middlewares.NewRecoveryMiddleware(responder).Middleware(
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				ctx := auth.ContextWithSession(r.Context(), &auth.Session{
+					Login: testUser.Login,
+					Email: testUser.Email,
+					User:  &testUser,
+				})
+				handler.ServeHTTP(w, r.WithContext(ctx))
+			}),
+		),
+	)
+	srv := httptest.NewServer(router)
+	t.Cleanup(srv.Close)
+
+	req, err := http.NewRequestWithContext(
+		context.Background(),
+		http.MethodGet,
+		srv.URL+"/api/file-manager/1/download-archive?disk=server&path=data",
+		nil,
+	)
+	require.NoError(t, err)
+
+	resp, err := srv.Client().Do(req)
+	require.NoError(t, err, "headers were sent before the failure, so the request itself succeeds")
+	t.Cleanup(func() { _ = resp.Body.Close() })
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "application/zip", resp.Header.Get("Content-Type"))
+
+	body, err := io.ReadAll(resp.Body)
+	require.Error(t, err, "client must observe a transport error instead of a complete body")
+	assert.ErrorIs(t, err, io.ErrUnexpectedEOF)
+	assert.LessOrEqual(t, len(body), len(partial), "nothing may be appended after the failure")
+	assert.True(t, guard.released, "concurrency slot must be released")
 }
 
 func TestArchiveFilename(t *testing.T) {

--- a/internal/api/filemanager/downloadarchive/handler_test.go
+++ b/internal/api/filemanager/downloadarchive/handler_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -161,7 +162,7 @@ func (s *stubArchiver) WriteArchive(
 
 type fakeGuard struct {
 	acquireErr error
-	released   bool
+	released   atomic.Bool
 }
 
 func (f *fakeGuard) Acquire(_ context.Context, _ uint) (func(), error) {
@@ -169,7 +170,7 @@ func (f *fakeGuard) Acquire(_ context.Context, _ uint) (func(), error) {
 		return nil, f.acquireErr
 	}
 
-	return func() { f.released = true }, nil
+	return func() { f.released.Store(true) }, nil
 }
 
 func TestHandler_ServeHTTP(t *testing.T) {
@@ -222,7 +223,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 				assert.Equal(t, "500", w.Header().Get("X-Archive-Total-Bytes"))
 				assert.Equal(t, "2", w.Header().Get("X-Archive-Total-Files"))
 				assert.Equal(t, "1", w.Header().Get("X-Archive-Skipped-Count"))
-				assert.True(t, g.released, "concurrency slot must be released")
+				assert.True(t, g.released.Load(), "concurrency slot must be released")
 
 				zr, err := zip.NewReader(bytes.NewReader(w.Body.Bytes()), int64(w.Body.Len()))
 				require.NoError(t, err)
@@ -475,7 +476,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 				assert.Equal(t, "500", w.Header().Get("X-Archive-Total-Bytes"))
 				assert.Equal(t, "PK\x03\x04partial-local-header", w.Body.String(),
 					"nothing may be appended after the partial archive bytes")
-				assert.True(t, g.released, "concurrency slot must be released while the panic unwinds")
+				assert.True(t, g.released.Load(), "concurrency slot must be released while the panic unwinds")
 			},
 		},
 		{
@@ -503,7 +504,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 				t.Helper()
 				assert.Equal(t, "application/zip", w.Header().Get("Content-Type"))
 				assert.Empty(t, w.Body.String())
-				assert.True(t, g.released, "concurrency slot must be released after a client cancel")
+				assert.True(t, g.released.Load(), "concurrency slot must be released after a client cancel")
 			},
 		},
 		{
@@ -801,7 +802,8 @@ func TestHandler_ServeHTTP_WriteFailureTruncatesResponseBody(t *testing.T) {
 	require.Error(t, err, "client must observe a transport error instead of a complete body")
 	assert.ErrorIs(t, err, io.ErrUnexpectedEOF)
 	assert.LessOrEqual(t, len(body), len(partial), "nothing may be appended after the failure")
-	assert.True(t, guard.released, "concurrency slot must be released")
+	assert.Eventually(t, guard.released.Load, time.Second, 10*time.Millisecond,
+		"concurrency slot must be released")
 }
 
 func TestArchiveFilename(t *testing.T) {

--- a/internal/api/middlewares/recovery.go
+++ b/internal/api/middlewares/recovery.go
@@ -25,6 +25,13 @@ func (m *RecoveryMiddleware) Middleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer func() {
 			if err := recover(); err != nil {
+				// net/http's own recovery treats this sentinel as "drop the connection without
+				// logging" — the way a streaming handler signals failure after headers were sent.
+				// Swallowing it here would let the response end as if it were complete.
+				if e, ok := err.(error); ok && errors.Is(e, http.ErrAbortHandler) {
+					panic(err)
+				}
+
 				// Capture stack trace
 				stack := debug.Stack()
 

--- a/internal/api/middlewares/recovery_test.go
+++ b/internal/api/middlewares/recovery_test.go
@@ -163,3 +163,26 @@ func TestRecoveryMiddleware_MultipleRequests(t *testing.T) {
 	wrappedPanicHandler.ServeHTTP(rec3, req3)
 	assert.Equal(t, http.StatusInternalServerError, rec3.Code)
 }
+
+func TestRecoveryMiddleware_RepanicsErrAbortHandler(t *testing.T) {
+	responder := api.NewResponder()
+	recoveryMiddleware := NewRecoveryMiddleware(responder)
+
+	abortingHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("partial-body"))
+		panic(http.ErrAbortHandler)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/stream", nil)
+	rec := httptest.NewRecorder()
+
+	handler := recoveryMiddleware.Middleware(abortingHandler)
+
+	require.PanicsWithValue(t, http.ErrAbortHandler, func() {
+		handler.ServeHTTP(rec, req)
+	}, "http.ErrAbortHandler must propagate to net/http so the connection is dropped")
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "partial-body", rec.Body.String(), "no JSON error may be appended to the streamed body")
+}

--- a/internal/services/filemanager/archiver/archiver.go
+++ b/internal/services/filemanager/archiver/archiver.go
@@ -71,16 +71,14 @@ func (a *Archiver) WriteArchive(
 
 	flusher := flusherFor(w)
 
+	// On error paths the zip writer is deliberately left unclosed: closing it would append a valid
+	// central directory and turn a partial stream into an archive that opens but silently lacks files.
 	for _, entry := range manifest.Entries {
 		if err := ctx.Err(); err != nil {
-			_ = zw.Close()
-
 			return nil, err
 		}
 
 		if err := a.writeEntry(ctx, zw, node, entry, opts); err != nil {
-			_ = zw.Close()
-
 			return nil, errors.WithMessage(err, "write entry "+entry.RelPath)
 		}
 
@@ -92,8 +90,6 @@ func (a *Archiver) WriteArchive(
 
 	if len(manifest.Skipped) > 0 {
 		if err := writeSkippedReport(zw, manifest.Skipped); err != nil {
-			_ = zw.Close()
-
 			return nil, errors.WithMessage(err, "write skipped report")
 		}
 	}

--- a/internal/services/filemanager/archiver/archiver_test.go
+++ b/internal/services/filemanager/archiver/archiver_test.go
@@ -190,6 +190,8 @@ func TestArchiver_WriteArchive(t *testing.T) {
 		assert.Nil(t, result)
 		assert.Contains(t, err.Error(), "open file stream", "wrap layer must surface")
 		assert.Contains(t, err.Error(), "daemon down", "underlying error message must propagate")
+		_, zipErr := zip.NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+		require.Error(t, zipErr, "partial output must not be finalized into a valid archive")
 	})
 
 	t.Run("close_stream_error_logged_archive_succeeds", func(t *testing.T) {
@@ -370,7 +372,8 @@ func TestArchiver_WriteArchive(t *testing.T) {
 			},
 		}
 		ctx, cancel := context.WithCancel(context.Background())
-		streamer := &cancellingStreamer{cancel: cancel, body: "x"}
+		// Larger than zip.Writer's internal bufio buffer so part of the entry reaches the output.
+		streamer := &cancellingStreamer{cancel: cancel, body: strings.Repeat("x", 16*1024)}
 		a := archiver.NewArchiver(lister, streamer, nil)
 		manifest, err := a.BuildManifest(ctx, node, "/work/server-1/data", archiver.Limits{})
 		require.NoError(t, err)
@@ -387,6 +390,9 @@ func TestArchiver_WriteArchive(t *testing.T) {
 			errors.Is(err, context.Canceled) || strings.Contains(err.Error(), "context canceled"),
 			"context cancellation must surface as ctx.Err: %v", err,
 		)
+		assert.Positive(t, buf.Len(), "the first entry was streamed before the cancellation")
+		_, zipErr := zip.NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+		require.Error(t, zipErr, "cancelled output must not be finalized into a valid archive")
 	})
 }
 

--- a/openapi/paths/file-manager.yaml
+++ b/openapi/paths/file-manager.yaml
@@ -503,6 +503,12 @@
       Symlinks are preserved as Unix-symlink entries inside the zip.
       Special files (sockets, FIFOs, devices) are skipped and listed in
       a trailing `_SKIPPED.txt` entry.
+
+      The body is streamed without `Content-Length`. If archive generation
+      fails after the response has started, the server aborts the connection
+      (truncated chunked body on HTTP/1.1, `RST_STREAM` on HTTP/2) instead of
+      ending the body cleanly, so a transport error while reading the body
+      means the archive is incomplete and must be discarded.
     operationId: downloadFileManagerArchive
     parameters:
       - name: server

--- a/openapi/paths/file-manager.yaml
+++ b/openapi/paths/file-manager.yaml
@@ -504,11 +504,13 @@
       Special files (sockets, FIFOs, devices) are skipped and listed in
       a trailing `_SKIPPED.txt` entry.
 
-      The body is streamed without `Content-Length`. If archive generation
-      fails after the response has started, the server aborts the connection
-      (truncated chunked body on HTTP/1.1, `RST_STREAM` on HTTP/2) instead of
-      ending the body cleanly, so a transport error while reading the body
-      means the archive is incomplete and must be discarded.
+      The body is streamed without `Content-Length`. A failure before the
+      first byte is sent is reported as a regular JSON error response. If
+      archive generation fails after the response has started, the server
+      aborts the connection (truncated chunked body on HTTP/1.1, `RST_STREAM`
+      on HTTP/2) instead of ending the body cleanly, so a transport error
+      while reading the body means the archive is incomplete and must be
+      discarded.
     operationId: downloadFileManagerArchive
     parameters:
       - name: server

--- a/web/frontend/js/filemanager/http/download-stream.js
+++ b/web/frontend/js/filemanager/http/download-stream.js
@@ -128,13 +128,19 @@ export async function streamSaveResponse({
         onProgress({ loaded: 0, total: effectiveTotal })
     }
 
+    if (signal && signal.aborted) {
+        throw new StreamDownloadError('aborted', 'Aborted')
+    }
+
     if (!window.isSecureContext) {
         return blobSaveResponse({ response, filename, effectiveTotal, signal, onProgress })
     }
 
+    // Size hints such as X-Archive-Total-Bytes describe the uncompressed payload, not the stream,
+    // so only a real Content-Length may become the browser download's Content-Length.
     const writable = streamSaver.createWriteStream(
         filename,
-        effectiveTotal > 0 ? { size: effectiveTotal } : undefined,
+        contentLength > 0 ? { size: contentLength } : undefined,
     )
 
     let loaded = 0
@@ -148,17 +154,8 @@ export async function streamSaveResponse({
         },
     })
 
-    const onAbort = () => {
-        try {
-            writable.abort?.('aborted by user')
-        } catch {
-            /* no-op */
-        }
-    }
-    if (signal) {
-        signal.addEventListener('abort', onAbort, { once: true })
-    }
-
+    // pipeTo owns cancellation: on abort it aborts the StreamSaver writable (the browser then
+    // discards the download as cancelled) and cancels the response body.
     try {
         await response.body.pipeThrough(progressTransform).pipeTo(writable, { signal })
     } catch (err) {
@@ -166,10 +163,6 @@ export async function streamSaveResponse({
             throw new StreamDownloadError('aborted', 'Aborted', err)
         }
         throw new StreamDownloadError('stream', err.message || 'Stream error', err)
-    } finally {
-        if (signal) {
-            signal.removeEventListener('abort', onAbort)
-        }
     }
 
     return { total: effectiveTotal, response }
@@ -180,12 +173,12 @@ async function blobSaveResponse({ response, filename, effectiveTotal, signal, on
     const chunks = []
     let loaded = 0
 
+    // Cancelling the reader unblocks a pending read() with done=true instead of an error,
+    // so the aborted check below the loop is what keeps a partial file from being saved.
     const onAbort = () => {
-        try {
-            reader.cancel('aborted by user')
-        } catch {
-            /* no-op */
-        }
+        reader.cancel('aborted by user').catch(() => {
+            /* the fetch abort may already have errored the stream */
+        })
     }
     if (signal) {
         signal.addEventListener('abort', onAbort, { once: true })
@@ -210,6 +203,10 @@ async function blobSaveResponse({ response, filename, effectiveTotal, signal, on
         if (signal) {
             signal.removeEventListener('abort', onAbort)
         }
+    }
+
+    if (signal && signal.aborted) {
+        throw new StreamDownloadError('aborted', 'Aborted')
     }
 
     const contentType = response.headers.get('Content-Type') || 'application/octet-stream'

--- a/web/frontend/js/filemanager/stores/useFileManagerStore.js
+++ b/web/frontend/js/filemanager/stores/useFileManagerStore.js
@@ -3,8 +3,9 @@ import { ref, computed, reactive } from 'vue'
 import GET from '../http/get.js'
 import POST from '../http/post.js'
 import { uploadFileChunked } from '../http/upload-session.js'
-import { downloadDirectoryArchive, ArchiveDownloadError } from '../http/download-archive.js'
-import { downloadSingleFile, FileDownloadError } from '../http/download-file.js'
+import { downloadDirectoryArchive } from '../http/download-archive.js'
+import { downloadSingleFile } from '../http/download-file.js'
+import { StreamDownloadError } from '../http/download-stream.js'
 import { detectConflicts, joinPath, dirOf } from '../http/upload-conflicts.js'
 import { useSettingsStore } from './useSettingsStore.js'
 import { useMessagesStore } from './useMessagesStore.js'
@@ -855,66 +856,90 @@ export const useFileManagerStore = defineStore('fm', () => {
         messages.clearUploadProgress()
     }
 
-    async function download({ disk, path, filename }) {
+    // Shared progress/cancel bookkeeping for single-file and archive downloads. Every store update
+    // is gated on isCurrent(): a cancelled or finished download must never touch the state of a
+    // download the user started afterwards, and a user cancel just clears the bar (no error flash).
+    async function trackDownload({ kind, filename, label, run }) {
         const messages = useMessagesStore()
-        const settings = useSettingsStore()
-
-        const fileName = filename || (path || '').split('/').filter(Boolean).pop() || 'file'
         const abortController = new AbortController()
-        messages.startArchiveDownload({ filename: fileName, abortController, kind: 'file' })
+        const { signal } = abortController
+        messages.startArchiveDownload({ filename, abortController, kind })
+
+        const isCurrent = () => messages.archiveDownload.abortController === abortController
+        const clearLater = (ms) => {
+            setTimeout(() => {
+                if (isCurrent()) messages.clearArchiveDownload()
+            }, ms)
+        }
 
         try {
-            await downloadSingleFile({
+            await run({
+                signal,
+                onPhase: (phase) => {
+                    if (isCurrent()) messages.setArchivePhase(phase)
+                },
+                onProgress: (progress) => {
+                    if (isCurrent()) messages.setArchiveProgress(progress)
+                },
+            })
+            clearLater(5000)
+        } catch (err) {
+            const code = err instanceof StreamDownloadError ? err.code : 'unknown'
+            if (code === 'aborted' || signal.aborted) {
+                if (isCurrent()) messages.clearArchiveDownload()
+                throw err
+            }
+            console.error(`[${label}] failed`, err)
+            const message = err && err.message ? err.message : 'unknown'
+            if (isCurrent()) messages.setArchiveError({ code, message })
+            clearLater(8000)
+            throw err
+        }
+    }
+
+    async function download({ disk, path, filename }) {
+        const settings = useSettingsStore()
+        const fileName = filename || (path || '').split('/').filter(Boolean).pop() || 'file'
+
+        await trackDownload({
+            kind: 'file',
+            filename: fileName,
+            label: 'download',
+            run: ({ signal, onPhase, onProgress }) => downloadSingleFile({
                 baseUrl: settings.baseUrl,
                 disk,
                 path,
                 filename: fileName,
                 headers: settings.headers,
-                onPhase: (phase) => messages.setArchivePhase(phase),
-                onProgress: (progress) => messages.setArchiveProgress(progress),
-                signal: abortController.signal,
-            })
-            setTimeout(() => messages.clearArchiveDownload(), 5000)
-        } catch (err) {
-            console.error('[download] failed', err)
-            const code = err instanceof FileDownloadError ? err.code : 'unknown'
-            const message = err && err.message ? err.message : 'unknown'
-            messages.setArchiveError({ code, message })
-            const dismissAfter = code === 'aborted' ? 1500 : 8000
-            setTimeout(() => messages.clearArchiveDownload(), dismissAfter)
-        }
+                onPhase,
+                onProgress,
+                signal,
+            }),
+        }).catch(() => {
+            /* errors are surfaced via the messages store */
+        })
     }
 
     async function downloadDirectory({ disk, path, filename, compress = 0 }) {
-        const messages = useMessagesStore()
         const settings = useSettingsStore()
-
         const archiveName = filename || `${(path || '').split('/').filter(Boolean).pop() || 'archive'}.zip`
-        const abortController = new AbortController()
-        messages.startArchiveDownload({ filename: archiveName, abortController })
 
-        try {
-            await downloadDirectoryArchive({
+        await trackDownload({
+            kind: 'archive',
+            filename: archiveName,
+            label: 'downloadDirectory',
+            run: ({ signal, onPhase, onProgress }) => downloadDirectoryArchive({
                 baseUrl: settings.baseUrl,
                 disk,
                 path,
                 filename: archiveName,
                 compress,
                 headers: settings.headers,
-                onPhase: (phase) => messages.setArchivePhase(phase),
-                onProgress: (progress) => messages.setArchiveProgress(progress),
-                signal: abortController.signal,
-            })
-            setTimeout(() => messages.clearArchiveDownload(), 5000)
-        } catch (err) {
-            console.error('[downloadDirectory] failed', err)
-            const code = err instanceof ArchiveDownloadError ? err.code : 'unknown'
-            const message = err && err.message ? err.message : 'unknown'
-            messages.setArchiveError({ code, message })
-            const dismissAfter = code === 'aborted' ? 1500 : 8000
-            setTimeout(() => messages.clearArchiveDownload(), dismissAfter)
-            throw err
-        }
+                onPhase,
+                onProgress,
+                signal,
+            }),
+        })
     }
 
     function sanitizeArchiveName(raw) {

--- a/web/frontend/tests/e2e/smoke/filemanager-archive-cancel.spec.ts
+++ b/web/frontend/tests/e2e/smoke/filemanager-archive-cancel.spec.ts
@@ -36,6 +36,7 @@ interface StubRequest {
 interface ArchiveStub {
   url: string;
   requests: StubRequest[];
+  request: (mode: StubMode) => StubRequest | undefined;
   close: () => Promise<void>;
 }
 
@@ -113,6 +114,7 @@ async function startArchiveStub(): Promise<ArchiveStub> {
   return {
     url: `http://127.0.0.1:${port}`,
     requests,
+    request: (mode) => requests.find((r) => r.mode === mode),
     close: () =>
       new Promise<void>((resolve, reject) => {
         server.closeAllConnections();
@@ -252,7 +254,7 @@ test.describe('file manager: download directory as ZIP', () => {
       await expect(progressBlock(page)).toContainText(ARCHIVE_NAME, { timeout: 20_000 });
       await expect(progressBlock(page)).not.toContainText('Downloading archive');
       await expect(progressBlock(page).getByRole('button', { name: /cancel/i })).toHaveCount(0);
-      expect(stub.requests[0]?.ended).toBe(true);
+      expect(stub.request('complete')?.ended).toBe(true);
     });
 
     test(`${ctxLabel}: cancel mid-stream saves nothing`, async ({ page, request }) => {
@@ -264,7 +266,7 @@ test.describe('file manager: download directory as ZIP', () => {
       page.on('download', (d) => downloads.push(d));
 
       await startArchiveDownload(page);
-      await expect.poll(() => stub.requests[0]?.sent ?? 0, { timeout: 20_000 }).toBeGreaterThan(2);
+      await expect.poll(() => stub.request('slow')?.sent ?? 0, { timeout: 20_000 }).toBeGreaterThan(2);
 
       await progressBlock(page).getByRole('button', { name: /cancel/i }).click();
 
@@ -275,7 +277,7 @@ test.describe('file manager: download directory as ZIP', () => {
       await expect(page.getByText('Archive download failed')).toHaveCount(0);
 
       // The server sees the disconnect (that is what cancels archive generation).
-      await expect.poll(() => stub.requests[0]?.closedEarly, { timeout: 20_000 }).toBe(true);
+      await expect.poll(() => stub.request('slow')?.closedEarly, { timeout: 20_000 }).toBe(true);
 
       if (secure) {
         // StreamSaver had already handed the stream to the browser: the browser-side

--- a/web/frontend/tests/e2e/smoke/filemanager-archive-cancel.spec.ts
+++ b/web/frontend/tests/e2e/smoke/filemanager-archive-cancel.spec.ts
@@ -1,0 +1,321 @@
+import { statSync } from 'node:fs';
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { test, expect, type Page } from '@playwright/test';
+import { loginViaAPI } from '../fixtures/auth';
+
+// "Download as ZIP" cancel/abort regression coverage. The file-manager API is
+// route-mocked (no daemon needed); the archive endpoint is redirected to a
+// local Node server that streams bytes slowly, so the download can be
+// cancelled or broken mid-stream deterministically.
+//
+// Two client paths exist and both are exercised: the StreamSaver/service-worker
+// path (secure context, the default on 127.0.0.1) and the in-memory Blob path
+// the app uses on plain http:// origins (forced via window.isSecureContext).
+
+const FILES_TAB = /files|файлы|servers\.files/i;
+const DOWNLOAD_DIR_TITLE = 'Download as ZIP';
+const ARCHIVE_NAME = 'E2E_FM_Server.zip';
+
+const CHUNK_SIZE = 64 * 1024;
+const COMPLETE_CHUNKS = 8;
+const CHUNK_INTERVAL_MS = 50;
+const SLOW_MAX_CHUNKS = 1200;
+
+const TS = 1752800000;
+
+type StubMode = 'complete' | 'slow' | 'abort';
+
+interface StubRequest {
+  mode: StubMode;
+  sent: number;
+  ended: boolean;
+  closedEarly: boolean;
+}
+
+interface ArchiveStub {
+  url: string;
+  requests: StubRequest[];
+  close: () => Promise<void>;
+}
+
+function fileEntry(path: string) {
+  const dot = path.lastIndexOf('.');
+
+  return {
+    path,
+    timestamp: TS,
+    type: 'file',
+    visibility: 'public',
+    size: 64,
+    dirname: '',
+    basename: path,
+    extension: dot > 0 ? path.slice(dot + 1) : undefined,
+    filename: dot > 0 ? path.slice(0, dot) : path,
+    mode: 420,
+  };
+}
+
+async function startArchiveStub(): Promise<ArchiveStub> {
+  const requests: StubRequest[] = [];
+  const server = http.createServer((req, res) => {
+    const url = new URL(req.url ?? '/', 'http://127.0.0.1');
+    const mode = (url.searchParams.get('mode') ?? 'complete') as StubMode;
+    const state: StubRequest = { mode, sent: 0, ended: false, closedEarly: false };
+    requests.push(state);
+
+    const totalChunks = mode === 'complete' ? COMPLETE_CHUNKS : SLOW_MAX_CHUNKS;
+    res.writeHead(200, {
+      'Content-Type': 'application/zip',
+      'Content-Disposition': `attachment; filename="${ARCHIVE_NAME}"`,
+      'X-Archive-Total-Bytes': String(totalChunks * CHUNK_SIZE),
+      'X-Archive-Total-Files': '3',
+      'X-Archive-Skipped-Count': '0',
+      'Cache-Control': 'no-store',
+    });
+    res.flushHeaders();
+
+    const chunk = Buffer.alloc(CHUNK_SIZE, 0x5a);
+    const timer = setInterval(() => {
+      if (res.destroyed) {
+        clearInterval(timer);
+
+        return;
+      }
+      if (mode === 'abort' && state.sent >= 3) {
+        clearInterval(timer);
+        res.destroy();
+
+        return;
+      }
+      if (state.sent >= totalChunks) {
+        clearInterval(timer);
+        state.ended = true;
+        res.end();
+
+        return;
+      }
+      res.write(chunk);
+      state.sent += 1;
+    }, CHUNK_INTERVAL_MS);
+
+    res.on('close', () => {
+      clearInterval(timer);
+      if (!state.ended) {
+        state.closedEarly = true;
+      }
+    });
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const { port } = server.address() as AddressInfo;
+
+  return {
+    url: `http://127.0.0.1:${port}`,
+    requests,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.closeAllConnections();
+        server.close((err) => (err ? reject(err) : resolve()));
+      }),
+  };
+}
+
+async function openFileManager(
+  page: Page,
+  token: string,
+  opts: { secure: boolean; stub: ArchiveStub; mode: StubMode },
+): Promise<void> {
+  await page.addInitScript((t) => localStorage.setItem('auth_token', t), token);
+  if (!opts.secure) {
+    // Same code path the app takes on a plain http://IP origin (Blob save).
+    await page.addInitScript(() => {
+      Object.defineProperty(window, 'isSecureContext', {
+        value: false,
+        configurable: true,
+      });
+    });
+  }
+
+  await page.route('**/api/servers/1/**', (route) => route.fulfill({ json: {} }));
+  await page.route('**/api/servers/1', (route) =>
+    route.fulfill({
+      json: {
+        id: 1,
+        uid: '11111111-1111-1111-1111-111111111111',
+        uuid: '11111111-1111-1111-1111-111111111111',
+        uuid_short: '11111111',
+        enabled: true,
+        installed: 1,
+        blocked: false,
+        name: 'E2E FM Server',
+        game_id: 'cs',
+        ds_id: 1,
+        game_mod_id: 1,
+        server_ip: '127.0.0.1',
+        server_port: 27015,
+        online: false,
+        game: { code: 'cs', name: 'Counter-Strike' },
+      },
+    }),
+  );
+  await page.route('**/api/servers/1/abilities', (route) =>
+    route.fulfill({
+      json: { 'game-server-common': true, 'game-server-files': true },
+    }),
+  );
+
+  await page.route('**/api/file-manager/1/**', (route) =>
+    route.fulfill({ json: { result: { status: 'success', message: '' } } }),
+  );
+  await page.route('**/api/file-manager/1/initialize*', (route) =>
+    route.fulfill({
+      json: {
+        result: { status: 'success', message: null },
+        config: {
+          acl: false,
+          hiddenFiles: true,
+          disks: { server: { driver: 'local' } },
+          lang: 'en',
+          leftDisk: 'server',
+          leftPath: '',
+          windowsConfig: 1,
+        },
+      },
+    }),
+  );
+  await page.route('**/api/file-manager/1/content*', (route) =>
+    route.fulfill({
+      json: {
+        result: { status: 'success', message: null },
+        directories: [],
+        files: [fileEntry('config.txt'), fileEntry('server.cfg')],
+      },
+    }),
+  );
+  // Redirect the archive request to the streaming stub; the browser still
+  // sees the app origin, so no CORS is involved.
+  await page.route('**/api/file-manager/1/download-archive*', (route) =>
+    route.continue({ url: `${opts.stub.url}/archive?mode=${opts.mode}` }),
+  );
+
+  await page.goto('/servers/1');
+  await page.locator('.n-tabs-tab', { hasText: FILES_TAB }).click({ timeout: 20_000 });
+  await expect(page.locator('.fm-row--file', { hasText: 'config.txt' })).toBeVisible({
+    timeout: 20_000,
+  });
+}
+
+function progressBlock(page: Page) {
+  return page.locator('.fm-progress-block');
+}
+
+async function startArchiveDownload(page: Page): Promise<void> {
+  await page.locator(`button.fm-tool-btn[title="${DOWNLOAD_DIR_TITLE}"]`).click();
+  await expect(progressBlock(page)).toContainText('Downloading archive', { timeout: 20_000 });
+}
+
+test.describe('file manager: download directory as ZIP', () => {
+  let stub: ArchiveStub;
+
+  test.beforeAll(async () => {
+    stub = await startArchiveStub();
+  });
+
+  test.afterAll(async () => {
+    await stub.close();
+  });
+
+  test.beforeEach(() => {
+    stub.requests.length = 0;
+  });
+
+  for (const secure of [true, false]) {
+    const ctxLabel = secure ? 'secure context (StreamSaver)' : 'insecure context (Blob)';
+
+    test(`${ctxLabel}: completed stream is saved in full`, async ({ page, request }) => {
+      test.setTimeout(90_000);
+      const token = await loginViaAPI(request);
+      await openFileManager(page, token, { secure, stub, mode: 'complete' });
+
+      const downloadPromise = page.waitForEvent('download', { timeout: 30_000 });
+      await startArchiveDownload(page);
+
+      const download = await downloadPromise;
+      expect(download.suggestedFilename()).toBe(ARCHIVE_NAME);
+      expect(await download.failure()).toBeNull();
+      const savedPath = await download.path();
+      expect(savedPath).not.toBeNull();
+      expect(statSync(savedPath as string).size).toBe(COMPLETE_CHUNKS * CHUNK_SIZE);
+
+      // Completed state shows the archive name and no Cancel button anymore.
+      await expect(progressBlock(page)).toContainText(ARCHIVE_NAME, { timeout: 20_000 });
+      await expect(progressBlock(page)).not.toContainText('Downloading archive');
+      await expect(progressBlock(page).getByRole('button', { name: /cancel/i })).toHaveCount(0);
+      expect(stub.requests[0]?.ended).toBe(true);
+    });
+
+    test(`${ctxLabel}: cancel mid-stream saves nothing`, async ({ page, request }) => {
+      test.setTimeout(90_000);
+      const token = await loginViaAPI(request);
+      await openFileManager(page, token, { secure, stub, mode: 'slow' });
+
+      const downloads: Array<{ failure: () => Promise<string | null> }> = [];
+      page.on('download', (d) => downloads.push(d));
+
+      await startArchiveDownload(page);
+      await expect.poll(() => stub.requests[0]?.sent ?? 0, { timeout: 20_000 }).toBeGreaterThan(2);
+
+      await progressBlock(page).getByRole('button', { name: /cancel/i }).click();
+
+      // The bar disappears and must not flash back as "completed" or as an error.
+      await expect(progressBlock(page)).toBeHidden({ timeout: 10_000 });
+      await page.waitForTimeout(2_000);
+      await expect(progressBlock(page)).toBeHidden();
+      await expect(page.getByText('Archive download failed')).toHaveCount(0);
+
+      // The server sees the disconnect (that is what cancels archive generation).
+      await expect.poll(() => stub.requests[0]?.closedEarly, { timeout: 20_000 }).toBe(true);
+
+      if (secure) {
+        // StreamSaver had already handed the stream to the browser: the browser-side
+        // download must end up cancelled/failed rather than completed.
+        await expect.poll(() => downloads.length, { timeout: 20_000 }).toBeGreaterThan(0);
+        for (const d of downloads) {
+          expect(await d.failure()).not.toBeNull();
+        }
+      } else {
+        // Blob path: no download may be triggered at all after a cancel.
+        await page.waitForTimeout(3_000);
+        expect(downloads).toHaveLength(0);
+      }
+    });
+
+    test(`${ctxLabel}: server abort mid-stream is reported as an error, nothing complete is saved`, async ({
+      page,
+      request,
+    }) => {
+      test.setTimeout(90_000);
+      const token = await loginViaAPI(request);
+      await openFileManager(page, token, { secure, stub, mode: 'abort' });
+
+      const downloads: Array<{ failure: () => Promise<string | null> }> = [];
+      page.on('download', (d) => downloads.push(d));
+
+      await startArchiveDownload(page);
+
+      await expect(progressBlock(page)).toContainText('Archive download failed', { timeout: 30_000 });
+      await expect(progressBlock(page)).not.toContainText('Downloading archive');
+
+      if (secure) {
+        await expect.poll(() => downloads.length, { timeout: 20_000 }).toBeGreaterThan(0);
+        for (const d of downloads) {
+          expect(await d.failure()).not.toBeNull();
+        }
+      } else {
+        await page.waitForTimeout(2_000);
+        expect(downloads).toHaveLength(0);
+      }
+    });
+  }
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of interrupted archive downloads so incomplete archives are not treated as successful.
  * Client-cancelled downloads now stop cleanly without unnecessary error messages.
  * File and archive downloads now provide more consistent progress, cancellation, cleanup, and error handling.
  * Aborted connections no longer return misleading server error responses.

* **Documentation**
  * Clarified that archive downloads are streamed and incomplete downloads must be discarded.

* **Tests**
  * Added coverage for cancellations, connection failures, truncated archives, and browser download behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->