### PR TITLE
Add FCaptcha provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,9 +379,10 @@ set. The login form discovers the provider and public site key through
 is sent as the `captcha` field of the login request and is verified before
 the user lookup.
 
-- `CAPTCHA_PROVIDER` - CAPTCHA provider (options: `recaptcha_v2`, `recaptcha_v3`, `turnstile`; empty disables CAPTCHA, default: empty)
+- `CAPTCHA_PROVIDER` - CAPTCHA provider (options: `recaptcha_v2`, `recaptcha_v3`, `turnstile`, `fcaptcha`; empty disables CAPTCHA, default: empty)
 - `CAPTCHA_SITE_KEY` - Public site key for the provider widget (safe to expose to browsers)
 - `CAPTCHA_SECRET_KEY` - Server-side secret key used to verify tokens (kept server-side)
+- `CAPTCHA_INSTANCE_URL` - Public base URL of the self-hosted FCaptcha server; required when `CAPTCHA_PROVIDER=fcaptcha`
 - `CAPTCHA_MIN_SCORE` - Pass threshold for reCAPTCHA v3 only, `0.0`–`1.0`; ignored by the checkbox/Turnstile providers (default: `0.5`)
 - `CAPTCHA_FAIL_OPEN` - Allow login when the provider's verify call itself fails (network/5xx). Default `false` (fail-closed: a verification outage blocks login with `503`)
 - `CAPTCHA_VERIFY_URL` - Override the provider's `siteverify` endpoint (egress proxies, testing). Empty uses the provider default
@@ -396,7 +397,8 @@ can extend the policy without patching the binary.
 
 The generated CSP automatically allow-lists exactly the origins required by
 the configured CAPTCHA provider (Google reCAPTCHA scripts/iframes for
-`recaptcha_v2`/`recaptcha_v3`; `challenges.cloudflare.com` for `turnstile`); with
+`recaptcha_v2`/`recaptcha_v3`; `challenges.cloudflare.com` for `turnstile`;
+the configured self-hosted origin for `fcaptcha`); with
 CAPTCHA disabled no third-party origins appear in the policy.
 
 HSTS is only emitted on TLS requests (`r.TLS != nil`, `X-Forwarded-Proto: https`
@@ -499,9 +501,10 @@ LOGGER_LEVEL=info
 # PLUGIN_STORE_LICENSE_KEY=your-license-key
 
 # CAPTCHA (login protection) — leave CAPTCHA_PROVIDER empty to disable
-# CAPTCHA_PROVIDER=turnstile          # recaptcha_v2 | recaptcha_v3 | turnstile
+# CAPTCHA_PROVIDER=turnstile          # recaptcha_v2 | recaptcha_v3 | turnstile | fcaptcha
 # CAPTCHA_SITE_KEY=your-public-site-key
 # CAPTCHA_SECRET_KEY=your-server-side-secret-key
+# CAPTCHA_INSTANCE_URL=https://captcha.example.com  # required for fcaptcha
 # CAPTCHA_MIN_SCORE=0.5               # reCAPTCHA v3 only
 # CAPTCHA_FAIL_OPEN=false             # true = allow login if the provider is unreachable
 

--- a/internal/api/middlewares/security_headers.go
+++ b/internal/api/middlewares/security_headers.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/fs"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/gameap/gameap/internal/config"
@@ -228,7 +229,10 @@ func buildPolicy(cfg *config.Config, staticFS fs.FS) (string, error) {
 func buildGeneratedCSP(cfg *config.Config, scriptHashes []string) string {
 	csp := &cfg.Security.CSP
 
-	captchaScript, captchaFrame := captchaCSPSources(cfg.Captcha.Provider)
+	captchaScript, captchaFrame, captchaConnect := captchaCSPSources(
+		cfg.Captcha.Provider,
+		cfg.Captcha.InstanceURL,
+	)
 
 	directives := []string{
 		"default-src 'self'",
@@ -245,7 +249,7 @@ func buildGeneratedCSP(cfg *config.Config, scriptHashes []string) string {
 		joinTokens("style-src", []string{"'self'", "'unsafe-inline'"}, csp.ExtraStyleSrc),
 		joinTokens("img-src", []string{"'self'", "data:", "blob:"}, csp.ExtraImgSrc),
 		joinTokens("font-src", []string{"'self'"}, csp.ExtraFontSrc),
-		joinTokens("connect-src", []string{"'self'"}, csp.ExtraConnectSrc),
+		joinTokens("connect-src", []string{"'self'"}, captchaConnect, csp.ExtraConnectSrc),
 		joinTokens("frame-src", []string{"'self'"}, captchaFrame, csp.ExtraFrameSrc),
 		joinTokens("worker-src", []string{"'self'", "blob:"}),
 	}
@@ -257,15 +261,31 @@ func buildGeneratedCSP(cfg *config.Config, scriptHashes []string) string {
 	return strings.Join(directives, "; ")
 }
 
-func captchaCSPSources(provider string) (script, frame []string) {
+func captchaCSPSources(provider, instanceURL string) (script, frame, connect []string) {
 	switch captcha.Provider(provider) {
 	case captcha.ProviderReCAPTCHAV2, captcha.ProviderReCAPTCHAV3:
-		return recaptchaScriptSrc, recaptchaFrameSrc
+		return recaptchaScriptSrc, recaptchaFrameSrc, nil
 	case captcha.ProviderTurnstile:
-		return turnstileScriptSrc, turnstileFrameSrc
+		return turnstileScriptSrc, turnstileFrameSrc, nil
+	case captcha.ProviderFCaptcha:
+		origin := captchaInstanceOrigin(instanceURL)
+		if origin == "" {
+			return nil, nil, nil
+		}
+
+		return []string{origin}, nil, []string{origin}
 	default:
-		return nil, nil
+		return nil, nil, nil
 	}
+}
+
+func captchaInstanceOrigin(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+		return ""
+	}
+
+	return u.Scheme + "://" + u.Host
 }
 
 // joinTokens writes "<name> <token1> <token2> …" by flattening any number of

--- a/internal/api/middlewares/security_headers_test.go
+++ b/internal/api/middlewares/security_headers_test.go
@@ -314,12 +314,21 @@ func TestSecurityHeaders_CSPCaptchaProviderMatrix(t *testing.T) {
 			wantTokens: []string{"https://challenges.cloudflare.com"},
 			forbidden:  []string{"google.com", "gstatic.com"},
 		},
+		{
+			name:       "fcaptcha_allows_configured_instance_only",
+			provider:   string(captcha.ProviderFCaptcha),
+			wantTokens: []string{"https://captcha.example.com"},
+			forbidden:  []string{"google.com", "gstatic.com", "challenges.cloudflare.com"},
+		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			cfg := baseSecureConfig()
 			cfg.Captcha.Provider = tc.provider
+			if tc.provider == string(captcha.ProviderFCaptcha) {
+				cfg.Captcha.InstanceURL = "https://captcha.example.com/path"
+			}
 
 			resp := runMiddleware(t, cfg, newTestFS(t), nil, nil)
 			csp := resp.Get("Content-Security-Policy")

--- a/internal/api/publicconfig/handler.go
+++ b/internal/api/publicconfig/handler.go
@@ -33,8 +33,9 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	if h.config.Captcha.Provider != "" {
 		resp.Captcha = &CaptchaConfig{
-			Provider: h.config.Captcha.Provider,
-			SiteKey:  h.config.Captcha.SiteKey,
+			Provider:    h.config.Captcha.Provider,
+			SiteKey:     h.config.Captcha.SiteKey,
+			InstanceURL: h.config.Captcha.InstanceURL,
 		}
 	}
 

--- a/internal/api/publicconfig/handler_test.go
+++ b/internal/api/publicconfig/handler_test.go
@@ -84,8 +84,8 @@ func TestHandler_ServeHTTP(t *testing.T) {
 }
 
 // TestHandler_ServeHTTP_Captcha pins that the public config advertises the
-// provider and site key when captcha is configured, never the secret, and
-// stays absent when no provider is set.
+// provider, site key and optional instance URL when captcha is configured,
+// never the secret, and stays absent when no provider is set.
 func TestHandler_ServeHTTP_Captcha(t *testing.T) {
 	t.Run("captcha_absent_when_provider_unset", func(t *testing.T) {
 		cfg := &config.Config{}
@@ -102,11 +102,12 @@ func TestHandler_ServeHTTP_Captcha(t *testing.T) {
 		assert.Nil(t, resp.Captcha)
 	})
 
-	t.Run("captcha_exposes_provider_and_site_key_only", func(t *testing.T) {
+	t.Run("captcha_exposes_public_widget_configuration_only", func(t *testing.T) {
 		cfg := &config.Config{}
-		cfg.Captcha.Provider = "turnstile"
+		cfg.Captcha.Provider = "fcaptcha"
 		cfg.Captcha.SiteKey = "site-key-123"
 		cfg.Captcha.SecretKey = "secret-key-should-not-leak"
+		cfg.Captcha.InstanceURL = "https://captcha.example.com"
 
 		responder := &mockResponder{}
 		NewHandler(cfg, responder).ServeHTTP(
@@ -117,8 +118,9 @@ func TestHandler_ServeHTTP_Captcha(t *testing.T) {
 		resp, ok := responder.lastResult.(Response)
 		require.True(t, ok)
 		require.NotNil(t, resp.Captcha)
-		assert.Equal(t, "turnstile", resp.Captcha.Provider)
+		assert.Equal(t, "fcaptcha", resp.Captcha.Provider)
 		assert.Equal(t, "site-key-123", resp.Captcha.SiteKey)
+		assert.Equal(t, "https://captcha.example.com", resp.Captcha.InstanceURL)
 
 		body, err := json.Marshal(resp)
 		require.NoError(t, err)

--- a/internal/api/publicconfig/response.go
+++ b/internal/api/publicconfig/response.go
@@ -9,6 +9,7 @@ type Response struct {
 // the login form needs to render the widget. The secret key is never
 // included here.
 type CaptchaConfig struct {
-	Provider string `json:"provider"`
-	SiteKey  string `json:"site_key"`
+	Provider    string `json:"provider"`
+	SiteKey     string `json:"site_key"`
+	InstanceURL string `json:"instance_url,omitempty"`
 }

--- a/internal/application/container.go
+++ b/internal/application/container.go
@@ -1696,12 +1696,13 @@ func (c *Container) createCaptchaVerifier() *captcha.Service {
 	cfg := c.Config().Captcha
 
 	return captcha.NewService(captcha.Config{
-		Provider:  captcha.Provider(cfg.Provider),
-		SiteKey:   cfg.SiteKey,
-		SecretKey: cfg.SecretKey,
-		MinScore:  cfg.MinScore,
-		FailOpen:  cfg.FailOpen,
-		VerifyURL: cfg.VerifyURL,
+		Provider:    captcha.Provider(cfg.Provider),
+		SiteKey:     cfg.SiteKey,
+		SecretKey:   cfg.SecretKey,
+		MinScore:    cfg.MinScore,
+		FailOpen:    cfg.FailOpen,
+		VerifyURL:   cfg.VerifyURL,
+		InstanceURL: cfg.InstanceURL,
 	})
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -241,10 +241,13 @@ type Config struct {
 	// stuffing. Empty Provider disables it; SecretKey stays server-side and
 	// is never exposed through /api/config/public.
 	Captcha struct {
-		// Provider: "" (disabled), "recaptcha_v2", "recaptcha_v3" or "turnstile".
+		// Provider: "" (disabled), "recaptcha_v2", "recaptcha_v3", "turnstile" or "fcaptcha".
 		Provider  string `env:"CAPTCHA_PROVIDER" envDefault:""`
 		SiteKey   string `env:"CAPTCHA_SITE_KEY" envDefault:""`
 		SecretKey string `env:"CAPTCHA_SECRET_KEY" envDefault:""`
+		// InstanceURL is the public base URL of a self-hosted CAPTCHA service.
+		// It is required by FCaptcha and exposed through /api/config/public.
+		InstanceURL string `env:"CAPTCHA_INSTANCE_URL" envDefault:""`
 		// MinScore is the reCAPTCHA v3 pass threshold (0.0–1.0); ignored by
 		// the checkbox/Turnstile providers that only return success.
 		MinScore float64 `env:"CAPTCHA_MIN_SCORE" envDefault:"0.5"`

--- a/internal/services/captcha/service.go
+++ b/internal/services/captcha/service.go
@@ -22,6 +22,7 @@ const (
 	ProviderReCAPTCHAV2 Provider = "recaptcha_v2"
 	ProviderReCAPTCHAV3 Provider = "recaptcha_v3"
 	ProviderTurnstile   Provider = "turnstile"
+	ProviderFCaptcha    Provider = "fcaptcha"
 )
 
 const (
@@ -44,12 +45,13 @@ var (
 // anonymous struct in internal/config so this package stays import-light and
 // independently testable.
 type Config struct {
-	Provider  Provider
-	SiteKey   string
-	SecretKey string
-	MinScore  float64
-	FailOpen  bool
-	VerifyURL string
+	Provider    Provider
+	SiteKey     string
+	SecretKey   string
+	MinScore    float64
+	FailOpen    bool
+	VerifyURL   string
+	InstanceURL string
 }
 
 // Option customises the service at construction time (test seams).
@@ -91,7 +93,7 @@ func NewService(cfg Config, opts ...Option) *Service {
 		secretKey: cfg.SecretKey,
 		minScore:  cfg.MinScore,
 		failOpen:  cfg.FailOpen,
-		verifyURL: resolveVerifyURL(cfg.Provider, cfg.VerifyURL),
+		verifyURL: resolveVerifyURL(cfg.Provider, cfg.VerifyURL, cfg.InstanceURL),
 		httpClient: &http.Client{
 			Timeout: defaultTimeout,
 		},
@@ -104,7 +106,7 @@ func NewService(cfg Config, opts ...Option) *Service {
 	return s
 }
 
-func resolveVerifyURL(provider Provider, override string) string {
+func resolveVerifyURL(provider Provider, override, instanceURL string) string {
 	if override != "" {
 		return override
 	}
@@ -114,6 +116,12 @@ func resolveVerifyURL(provider Provider, override string) string {
 		return turnstileVerifyURL
 	case ProviderReCAPTCHAV2, ProviderReCAPTCHAV3:
 		return recaptchaVerifyURL
+	case ProviderFCaptcha:
+		if instanceURL == "" {
+			return ""
+		}
+
+		return strings.TrimRight(instanceURL, "/") + "/turnstile/v0/siteverify"
 	case ProviderNone:
 		return ""
 	default:

--- a/internal/services/captcha/service.go
+++ b/internal/services/captcha/service.go
@@ -121,7 +121,16 @@ func resolveVerifyURL(provider Provider, override, instanceURL string) string {
 			return ""
 		}
 
-		return strings.TrimRight(instanceURL, "/") + "/turnstile/v0/siteverify"
+		u, err := url.Parse(instanceURL)
+		if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" ||
+			u.User != nil || u.RawQuery != "" || u.Fragment != "" {
+			return ""
+		}
+
+		u.Path = strings.TrimRight(u.Path, "/") + "/turnstile/v0/siteverify"
+		u.RawPath = ""
+
+		return u.String()
 	case ProviderNone:
 		return ""
 	default:

--- a/internal/services/captcha/service_test.go
+++ b/internal/services/captcha/service_test.go
@@ -250,8 +250,20 @@ func TestResolveVerifyURL(t *testing.T) {
 		{
 			name:     "fcaptcha_uses_instance_endpoint",
 			provider: ProviderFCaptcha,
-			instance: "https://captcha.example.com/",
-			want:     "https://captcha.example.com/turnstile/v0/siteverify",
+			instance: "https://captcha.example.com/base/",
+			want:     "https://captcha.example.com/base/turnstile/v0/siteverify",
+		},
+		{
+			name:     "fcaptcha_rejects_instance_query",
+			provider: ProviderFCaptcha,
+			instance: "https://captcha.example.com?tenant=1",
+			want:     "",
+		},
+		{
+			name:     "fcaptcha_rejects_non_http_instance",
+			provider: ProviderFCaptcha,
+			instance: "javascript:alert(1)",
+			want:     "",
 		},
 		{
 			name:     "fcaptcha_without_instance_has_no_endpoint",

--- a/internal/services/captcha/service_test.go
+++ b/internal/services/captcha/service_test.go
@@ -65,6 +65,18 @@ func TestService_Enabled(t *testing.T) {
 			cfg:  Config{Provider: ProviderReCAPTCHAV2, SecretKey: "secret"},
 			want: true,
 		},
+		{
+			name: "enabled_fcaptcha",
+			cfg: Config{
+				Provider: ProviderFCaptcha, SecretKey: "secret", InstanceURL: "https://captcha.example.com",
+			},
+			want: true,
+		},
+		{
+			name: "disabled_fcaptcha_without_instance_url",
+			cfg:  Config{Provider: ProviderFCaptcha, SecretKey: "secret"},
+			want: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -111,6 +123,16 @@ func TestService_Verify(t *testing.T) {
 		{
 			name:         "turnstile_success",
 			cfg:          Config{Provider: ProviderTurnstile, SecretKey: "secret"},
+			token:        "tok",
+			serverStatus: http.StatusOK,
+			serverBody:   verifyResponse{Success: true},
+			wantError:    "",
+		},
+		{
+			name: "fcaptcha_success",
+			cfg: Config{
+				Provider: ProviderFCaptcha, SecretKey: "secret", InstanceURL: "https://captcha.example.com",
+			},
 			token:        "tok",
 			serverStatus: http.StatusOK,
 			serverBody:   verifyResponse{Success: true},
@@ -207,6 +229,7 @@ func TestResolveVerifyURL(t *testing.T) {
 		name     string
 		provider Provider
 		override string
+		instance string
 		want     string
 	}{
 		{
@@ -223,6 +246,17 @@ func TestResolveVerifyURL(t *testing.T) {
 			name:     "recaptcha_v3_default_endpoint",
 			provider: ProviderReCAPTCHAV3,
 			want:     "https://www.google.com/recaptcha/api/siteverify",
+		},
+		{
+			name:     "fcaptcha_uses_instance_endpoint",
+			provider: ProviderFCaptcha,
+			instance: "https://captcha.example.com/",
+			want:     "https://captcha.example.com/turnstile/v0/siteverify",
+		},
+		{
+			name:     "fcaptcha_without_instance_has_no_endpoint",
+			provider: ProviderFCaptcha,
+			want:     "",
 		},
 		{
 			name:     "provider_none_has_no_endpoint",
@@ -257,7 +291,7 @@ func TestResolveVerifyURL(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// ACT
-			got := resolveVerifyURL(tt.provider, tt.override)
+			got := resolveVerifyURL(tt.provider, tt.override, tt.instance)
 
 			// ASSERT
 			assert.Equal(t, tt.want, got, "resolved siteverify endpoint mismatch")

--- a/openapi/schemas/responses/PublicConfigResponse.yaml
+++ b/openapi/schemas/responses/PublicConfigResponse.yaml
@@ -18,11 +18,17 @@ properties:
           - recaptcha_v2
           - recaptcha_v3
           - turnstile
+          - fcaptcha
         example: "turnstile"
       site_key:
         type: string
         description: Public site key for the provider widget
         example: "1x00000000000000000000AA"
+      instance_url:
+        type: string
+        format: uri
+        description: Public base URL of the self-hosted CAPTCHA service; present for FCaptcha
+        example: "https://captcha.example.com"
     required:
       - provider
       - site_key

--- a/web/frontend/js/views/LoginView.vue
+++ b/web/frontend/js/views/LoginView.vue
@@ -35,6 +35,7 @@
                   ref="captchaRef"
                   :provider="captcha.provider"
                   :site-key="captcha.site_key"
+                  :instance-url="captcha.instance_url"
               />
             </form>
           </div>
@@ -72,7 +73,7 @@ const email = ref(null)
 const password = ref(null)
 const remember = ref(false)
 const twoFactorRequired = ref(false)
-const captcha = ref({provider: null, site_key: null})
+const captcha = ref({provider: null, site_key: null, instance_url: null})
 const captchaRef = ref(null)
 
 onMounted(async () => {

--- a/web/frontend/js/views/forms/CaptchaWidget.vue
+++ b/web/frontend/js/views/forms/CaptchaWidget.vue
@@ -8,16 +8,17 @@ import { onMounted, ref } from "vue"
 const props = defineProps({
   provider: { type: String, required: true },
   siteKey: { type: String, required: true },
+  instanceUrl: { type: String, default: "" },
 })
 
 const containerRef = ref(null)
 const token = ref("")
 let widgetId = null
 
-// recaptcha_v2 and turnstile render a visible challenge and report the
+// recaptcha_v2, turnstile and fcaptcha render a visible challenge and report the
 // solution through a callback; recaptcha_v3 is invisible and produces a
 // fresh token on demand at submit time.
-const isWidget = props.provider === "recaptcha_v2" || props.provider === "turnstile"
+const isWidget = ["recaptcha_v2", "turnstile", "fcaptcha"].includes(props.provider)
 
 const scriptCache = {}
 
@@ -90,6 +91,27 @@ const renderTurnstile = async () => {
   })
 }
 
+const renderFCaptcha = async () => {
+  const instanceUrl = props.instanceUrl.replace(/\/+$/, "")
+  if (!instanceUrl) {
+    throw new Error("FCaptcha instance URL is not configured")
+  }
+
+  await loadScript(`${instanceUrl}/fcaptcha.js`)
+  await waitFor(() => window.FCaptcha && window.FCaptcha.render)
+
+  window.FCaptcha.configure({ serverUrl: instanceUrl })
+  widgetId = window.FCaptcha.render(containerRef.value, {
+    siteKey: props.siteKey,
+    callback: (t) => {
+      token.value = t
+    },
+    errorCallback: () => {
+      token.value = ""
+    },
+  })
+}
+
 const loadRecaptchaV3 = async () => {
   await loadScript(`https://www.google.com/recaptcha/api.js?render=${props.siteKey}`)
   await waitFor(() => window.grecaptcha && window.grecaptcha.execute)
@@ -100,6 +122,8 @@ onMounted(() => {
     renderRecaptchaV2().catch((e) => console.error(e))
   } else if (props.provider === "turnstile") {
     renderTurnstile().catch((e) => console.error(e))
+  } else if (props.provider === "fcaptcha") {
+    renderFCaptcha().catch((e) => console.error(e))
   } else if (props.provider === "recaptcha_v3") {
     loadRecaptchaV3().catch((e) => console.error(e))
   }
@@ -130,6 +154,8 @@ const reset = () => {
     window.grecaptcha.reset(widgetId)
   } else if (props.provider === "turnstile" && window.turnstile) {
     window.turnstile.reset(widgetId)
+  } else if (props.provider === "fcaptcha" && window.FCaptcha) {
+    window.FCaptcha.reset(widgetId)
   }
 }
 

--- a/web/frontend/js/views/forms/CaptchaWidget.vue
+++ b/web/frontend/js/views/forms/CaptchaWidget.vue
@@ -33,7 +33,11 @@ const loadScript = (src) => {
     el.async = true
     el.defer = true
     el.onload = () => resolve()
-    el.onerror = () => reject(new Error(`failed to load ${src}`))
+    el.onerror = () => {
+      delete scriptCache[src]
+      el.remove()
+      reject(new Error(`failed to load ${src}`))
+    }
     document.head.appendChild(el)
   })
 

--- a/web/frontend/js/views/forms/CaptchaWidget.vue
+++ b/web/frontend/js/views/forms/CaptchaWidget.vue
@@ -59,6 +59,16 @@ const waitFor = (predicate, timeout = 10000) =>
     tick()
   })
 
+const normalizeInstanceUrl = (rawUrl) => {
+  const url = new URL(rawUrl)
+  if (!["http:", "https:"].includes(url.protocol) || url.username || url.password || url.search || url.hash) {
+    throw new Error("FCaptcha instance URL must be an HTTP(S) base URL")
+  }
+
+  url.pathname = url.pathname.replace(/\/+$/, "")
+  return url.toString().replace(/\/$/, "")
+}
+
 const renderRecaptchaV2 = async () => {
   await loadScript("https://www.google.com/recaptcha/api.js?render=explicit")
   await waitFor(() => window.grecaptcha && window.grecaptcha.render)
@@ -96,7 +106,7 @@ const renderTurnstile = async () => {
 }
 
 const renderFCaptcha = async () => {
-  const instanceUrl = props.instanceUrl.replace(/\/+$/, "")
+  const instanceUrl = normalizeInstanceUrl(props.instanceUrl)
   if (!instanceUrl) {
     throw new Error("FCaptcha instance URL is not configured")
   }


### PR DESCRIPTION
## Summary

- add `fcaptcha` to the CAPTCHA provider service and derive its Siteverify endpoint from a configured self-hosted instance
- expose the public instance URL to the login UI without exposing the verification secret
- render, reset, and collect tokens from the FCaptcha widget in the Vue login form
- add the configured FCaptcha origin to generated `script-src` and `connect-src` CSP directives
- update OpenAPI, configuration examples, and README documentation
- cover provider enablement, verification URL resolution, verification success, public configuration, and CSP behavior

## Configuration

```dotenv
CAPTCHA_PROVIDER=fcaptcha
CAPTCHA_INSTANCE_URL=https://captcha.example.com
CAPTCHA_SITE_KEY=your-site-key
CAPTCHA_SECRET_KEY=your-verify-secret
```

`CAPTCHA_VERIFY_URL` remains available as a backend-only override.

## Validation

- `go test ./...`
- `npm run build` in `web/frontend`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for FCaptcha, including self-hosted instance URLs.
  * FCaptcha is available on the login screen alongside existing CAPTCHA providers.
  * Public configuration now exposes the optional CAPTCHA instance URL.

* **Documentation**
  * Updated configuration, provider, CSP guidance, and examples for FCaptcha.

* **Security**
  * Content security policies now allow validated FCaptcha instance origins.
  * Improved CAPTCHA script recovery after failed loads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->