### PR TITLE
nodefs plugin update

### DIFF
--- a/internal/api/plugins/fileref/byterange.go
+++ b/internal/api/plugins/fileref/byterange.go
@@ -1,0 +1,93 @@
+package fileref
+
+import (
+	"strconv"
+	"strings"
+)
+
+// byteRange is one resolved half-open-free range: both ends inclusive, both
+// inside the file.
+type byteRange struct {
+	start uint64
+	// length is always at least 1 — an empty range is not representable and
+	// never produced.
+	length uint64
+}
+
+// parseByteRange resolves a Range header against a known file size.
+//
+// Only a single range is honoured. A multi-range request would have to be
+// answered as multipart/byteranges, and the one thing ranges are for here —
+// resuming an interrupted download — never asks for more than one. An
+// unsupported or malformed header answers ok = false, which the caller turns
+// into an ordinary whole-file response, exactly as RFC 9110 allows.
+//
+// satisfiable = false marks a syntactically valid range that lies past the end
+// of the file; that one owes the client a 416 rather than the whole file.
+func parseByteRange(header string, size uint64) (rng byteRange, ok bool, satisfiable bool) {
+	spec, found := strings.CutPrefix(strings.TrimSpace(header), "bytes=")
+	if !found {
+		return byteRange{}, false, false
+	}
+
+	spec = strings.TrimSpace(spec)
+	if spec == "" || strings.Contains(spec, ",") {
+		return byteRange{}, false, false
+	}
+
+	first, last, found := strings.Cut(spec, "-")
+	if !found {
+		return byteRange{}, false, false
+	}
+
+	first, last = strings.TrimSpace(first), strings.TrimSpace(last)
+
+	// "bytes=-N": the final N bytes.
+	if first == "" {
+		suffix, err := strconv.ParseUint(last, 10, 64)
+		if err != nil || suffix == 0 {
+			return byteRange{}, false, false
+		}
+
+		if size == 0 {
+			return byteRange{}, true, false
+		}
+
+		if suffix > size {
+			suffix = size
+		}
+
+		return byteRange{start: size - suffix, length: suffix}, true, true
+	}
+
+	start, err := strconv.ParseUint(first, 10, 64)
+	if err != nil {
+		return byteRange{}, false, false
+	}
+
+	if start >= size {
+		return byteRange{}, true, false
+	}
+
+	// "bytes=N-": from N to the end.
+	if last == "" {
+		return byteRange{start: start, length: size - start}, true, true
+	}
+
+	end, err := strconv.ParseUint(last, 10, 64)
+	if err != nil || end < start {
+		return byteRange{}, false, false
+	}
+
+	if end >= size {
+		end = size - 1
+	}
+
+	return byteRange{start: start, length: end - start + 1}, true, true
+}
+
+// contentRange is the Content-Range value for a served range.
+func (r byteRange) contentRange(size uint64) string {
+	return "bytes " + strconv.FormatUint(r.start, 10) + "-" +
+		strconv.FormatUint(r.start+r.length-1, 10) + "/" + strconv.FormatUint(size, 10)
+}

--- a/internal/api/plugins/fileref/byterange_test.go
+++ b/internal/api/plugins/fileref/byterange_test.go
@@ -1,0 +1,75 @@
+package fileref
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseByteRange(t *testing.T) {
+	t.Parallel()
+
+	const size = 100
+
+	tests := []struct {
+		name            string
+		header          string
+		wantOK          bool
+		wantSatisfiable bool
+		wantStart       uint64
+		wantLength      uint64
+	}{
+		{name: "absent", header: "", wantOK: false},
+		{name: "other_unit", header: "items=0-10", wantOK: false},
+		{name: "closed", header: "bytes=0-9", wantOK: true, wantSatisfiable: true, wantStart: 0, wantLength: 10},
+		{name: "open_ended", header: "bytes=90-", wantOK: true, wantSatisfiable: true, wantStart: 90, wantLength: 10},
+		{name: "suffix", header: "bytes=-10", wantOK: true, wantSatisfiable: true, wantStart: 90, wantLength: 10},
+		{
+			name:   "suffix_longer_than_the_file_is_the_whole_file",
+			header: "bytes=-500", wantOK: true, wantSatisfiable: true, wantStart: 0, wantLength: size,
+		},
+		{
+			name:   "end_past_the_file_is_clamped",
+			header: "bytes=95-500", wantOK: true, wantSatisfiable: true, wantStart: 95, wantLength: 5,
+		},
+		{name: "start_past_the_file", header: "bytes=100-", wantOK: true, wantSatisfiable: false},
+		{name: "reversed", header: "bytes=20-10", wantOK: false},
+		{name: "garbage", header: "bytes=abc", wantOK: false},
+		{name: "no_dash", header: "bytes=10", wantOK: false},
+		// Multi-range would owe the client a multipart/byteranges body; a
+		// resumed download never asks for one, so it falls back to the whole
+		// file rather than being answered wrongly.
+		{name: "multi_range_falls_back", header: "bytes=0-9,20-29", wantOK: false},
+		{name: "whitespace_is_tolerated", header: " bytes= 5 - 9 ", wantOK: true, wantSatisfiable: true, wantStart: 5, wantLength: 5},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			rng, ok, satisfiable := parseByteRange(tt.header, size)
+			assert.Equal(t, tt.wantOK, ok)
+			assert.Equal(t, tt.wantSatisfiable, satisfiable)
+
+			if tt.wantSatisfiable {
+				assert.Equal(t, tt.wantStart, rng.start)
+				assert.Equal(t, tt.wantLength, rng.length)
+			}
+		})
+	}
+}
+
+func TestParseByteRange_an_empty_file_satisfies_nothing(t *testing.T) {
+	t.Parallel()
+
+	_, ok, satisfiable := parseByteRange("bytes=-10", 0)
+	assert.True(t, ok)
+	assert.False(t, satisfiable)
+}
+
+func TestByteRange_contentRange(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "bytes 90-99/100", byteRange{start: 90, length: 10}.contentRange(100))
+	assert.Equal(t, "bytes 0-0/1", byteRange{start: 0, length: 1}.contentRange(1))
+}

--- a/internal/api/plugins/fileref/contracts.go
+++ b/internal/api/plugins/fileref/contracts.go
@@ -13,6 +13,11 @@ import (
 type FileService interface {
 	GetFileInfo(ctx context.Context, node *domain.Node, path string) (*daemon.FileDetails, error)
 	DownloadStream(ctx context.Context, node *domain.Node, filePath string) (io.ReadCloser, error)
+	// DownloadStreamRange serves a byte range, which is what makes an
+	// interrupted download resumable instead of starting over.
+	DownloadStreamRange(
+		ctx context.Context, node *domain.Node, filePath string, offset, length uint64,
+	) (io.ReadCloser, error)
 }
 
 // PermissionChecker answers whether the plugin holds a grant; satisfied by

--- a/internal/api/plugins/fileref/server.go
+++ b/internal/api/plugins/fileref/server.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"math"
 	"net/http"
 	"path"
 	"strconv"
@@ -39,6 +40,7 @@ var (
 	errFilesPermissionRequired = errors.New("plugin permission " + string(domain.PluginPermissionFilesRead) + " required")
 	errAuthenticationRequired  = errors.New("authentication required for file responses")
 	errInvalidStatusCode       = errors.New("invalid plugin status code")
+	errRangeNotSatisfiable     = errors.New("requested range is past the end of the file")
 )
 
 // allowedPluginHeaders is the only set of plugin-provided headers that
@@ -164,7 +166,20 @@ func (s *Server) ServeFileRef(w http.ResponseWriter, r *http.Request, req pkgplu
 		return api.WrapHTTPError(errPathIsDirectory, http.StatusBadRequest)
 	}
 
-	stream, err := s.files.DownloadStream(ctx, node, req.Ref.Path)
+	// A range only makes sense for an ordinary 200 answer; a plugin that chose
+	// its own status has said something the transfer layer should not rewrite.
+	served, ok, satisfiable := byteRange{}, false, false
+	if effectiveStatus(req) == http.StatusOK {
+		served, ok, satisfiable = parseByteRange(r.Header.Get("Range"), info.Size)
+	}
+
+	if ok && !satisfiable {
+		w.Header().Set("Content-Range", "bytes */"+strconv.FormatUint(info.Size, 10))
+
+		return api.WrapHTTPError(errRangeNotSatisfiable, http.StatusRequestedRangeNotSatisfiable)
+	}
+
+	stream, err := s.open(ctx, node, req, served, ok)
 	if err != nil {
 		return errors.WithMessage(err, "failed to open file stream")
 	}
@@ -174,9 +189,40 @@ func (s *Server) ServeFileRef(w http.ResponseWriter, r *http.Request, req pkgplu
 		}
 	}()
 
-	s.stream(w, r, req, info, stream)
+	if ok {
+		s.stream(w, r, req, info, stream, &served)
+	} else {
+		s.stream(w, r, req, info, stream, nil)
+	}
 
 	return nil
+}
+
+// open picks the whole-file stream or the ranged one. They are different daemon
+// calls: the plain stream may use the node's transfer task, which has no start
+// offset, so a range has to go the chunked way.
+func (s *Server) open(
+	ctx context.Context,
+	node *domain.Node,
+	req pkgplugin.FileRefRequest,
+	served byteRange,
+	ranged bool,
+) (io.ReadCloser, error) {
+	if ranged {
+		return s.files.DownloadStreamRange(ctx, node, req.Ref.Path, served.start, served.length)
+	}
+
+	return s.files.DownloadStream(ctx, node, req.Ref.Path)
+}
+
+// effectiveStatus is the status the response will carry: the plugin's, or 200
+// when it named none.
+func effectiveStatus(req pkgplugin.FileRefRequest) int {
+	if req.StatusCode == 0 {
+		return http.StatusOK
+	}
+
+	return req.StatusCode
 }
 
 // stream writes the headers and copies the file. Nothing can be reported to
@@ -188,6 +234,7 @@ func (s *Server) stream(
 	req pkgplugin.FileRefRequest,
 	info *daemon.FileDetails,
 	stream io.Reader,
+	served *byteRange,
 ) {
 	ctx := r.Context()
 
@@ -195,11 +242,15 @@ func (s *Server) stream(
 		slog.WarnContext(ctx, "failed to disable write deadline", slog.String("error", err.Error()))
 	}
 
-	applyHeaders(w.Header(), req)
+	applyHeaders(w.Header(), req, info)
 
-	status := req.StatusCode
-	if status == 0 {
-		status = http.StatusOK
+	status := effectiveStatus(req)
+
+	if served != nil {
+		w.Header().Set("Content-Length", strconv.FormatUint(served.length, 10))
+		w.Header().Set("Content-Range", served.contentRange(info.Size))
+
+		status = http.StatusPartialContent
 	}
 
 	w.WriteHeader(status)
@@ -213,19 +264,46 @@ func (s *Server) stream(
 		slog.Uint64("user_id", requestUserID(ctx)),
 	)
 
-	if _, err := io.Copy(w, stream); err != nil {
+	// Bounded by the length just declared: a stream that grew between the stat
+	// and the read must not run past it, or the client keeps a body longer than
+	// the header promised. A stream that shrank instead ends the copy short,
+	// which net/http reports as a failed response rather than a clean end —
+	// which is the point, since a silently truncated archive is worse than a
+	// download that visibly fails.
+	expected := info.Size
+	if served != nil {
+		expected = served.length
+	}
+
+	declared := int64(min(expected, math.MaxInt64)) //nolint:gosec // G115: clamped to MaxInt64 just before
+
+	written, err := io.Copy(w, io.LimitReader(stream, declared))
+	if err != nil {
 		slog.ErrorContext(ctx, "failed to write plugin file response",
 			slog.Uint64("plugin_id", req.PluginID),
 			slog.String("path", req.Ref.Path),
 			slog.String("error", err.Error()))
+
+		return
+	}
+
+	if written != declared {
+		slog.ErrorContext(ctx, "plugin file response is shorter than the file it stat'ed",
+			slog.Uint64("plugin_id", req.PluginID),
+			slog.String("path", req.Ref.Path),
+			slog.Int64("declared", declared),
+			slog.Int64("written", written))
 	}
 }
 
-// applyHeaders copies the plugin headers the allowlist admits and then
-// sets the ones the panel owns: the file is always an attachment. No
-// Content-Length is declared: the stat and the stream are separate daemon
-// calls, so the size may not match the bytes actually streamed.
-func applyHeaders(header http.Header, req pkgplugin.FileRefRequest) {
+// applyHeaders copies the plugin headers the allowlist admits and then sets
+// the ones the panel owns: the file is always an attachment, and its length is
+// the one the stat reported. The stat and the stream are separate daemon calls,
+// so the two can disagree — the copy is bounded by this same length and a
+// disagreement ends the response as an error, which is what tells the client
+// its file is incomplete. Without a declared length the body is chunked and a
+// truncated transfer ends looking exactly like a complete one.
+func applyHeaders(header http.Header, req pkgplugin.FileRefRequest, info *daemon.FileDetails) {
 	for name, value := range req.Headers {
 		if pluginHeaderAllowed(name) {
 			header.Set(name, value)
@@ -233,7 +311,8 @@ func applyHeaders(header http.Header, req pkgplugin.FileRefRequest) {
 	}
 
 	filemanagerhttp.AttachmentContentHeaders(header, attachmentName(req.Ref), header.Get("Content-Type"))
-	header.Set("Accept-Ranges", "none")
+	header.Set("Accept-Ranges", "bytes")
+	header.Set("Content-Length", strconv.FormatUint(info.Size, 10))
 
 	if header.Get("Cache-Control") == "" {
 		header.Set("Cache-Control", "no-store")
@@ -314,7 +393,7 @@ func (s *Server) authorize(ctx context.Context, req pkgplugin.FileRefRequest) er
 // checkPathPolicy applies the node path policy to the file the plugin wants
 // served; a refusal is audited like a refused host call.
 func (s *Server) checkPathPolicy(ctx context.Context, node *domain.Node, req pkgplugin.FileRefRequest) error {
-	scope, err := s.policy.ScopeFor(ctx, node)
+	scope, err := s.policy.ScopeFor(ctx, node, req.PluginID)
 	if err != nil {
 		return errors.WithMessage(err, "failed to resolve the node path policy")
 	}

--- a/internal/api/plugins/fileref/server_test.go
+++ b/internal/api/plugins/fileref/server_test.go
@@ -75,6 +75,10 @@ type fakeFileService struct {
 	infoCalls  int
 	streamOpen *closeRecorder
 	reader     io.Reader
+	// What the last ranged read asked for, so a test can assert the window
+	// reached the daemon rather than being trimmed on the way out.
+	rangeOffset uint64
+	rangeLength uint64
 }
 
 func (f *fakeFileService) GetFileInfo(_ context.Context, _ *domain.Node, _ string) (*daemon.FileDetails, error) {
@@ -87,6 +91,34 @@ func (f *fakeFileService) GetFileInfo(_ context.Context, _ *domain.Node, _ strin
 	}
 
 	return f.info, nil
+}
+
+func (f *fakeFileService) DownloadStreamRange(
+	_ context.Context, _ *domain.Node, _ string, offset, length uint64,
+) (io.ReadCloser, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if f.streamErr != nil {
+		return nil, f.streamErr
+	}
+
+	f.rangeOffset, f.rangeLength = offset, length
+
+	window := f.content
+	if offset < uint64(len(window)) {
+		window = window[offset:]
+	} else {
+		window = ""
+	}
+
+	if length > 0 && uint64(len(window)) > length {
+		window = window[:length]
+	}
+
+	f.streamOpen = &closeRecorder{Reader: strings.NewReader(window)}
+
+	return f.streamOpen, nil
 }
 
 func (f *fakeFileService) DownloadStream(_ context.Context, _ *domain.Node, _ string) (io.ReadCloser, error) {
@@ -170,10 +202,10 @@ func TestServeFileRef_streams_attachment(t *testing.T) {
 	assert.Equal(t, "a,b\n1", w.Body.String())
 	assert.Equal(t, "text/csv; charset=utf-8", w.Header().Get("Content-Type"))
 	assert.Equal(t, `attachment; filename=report.csv; filename*=UTF-8''report.csv`, w.Header().Get("Content-Disposition"))
-	assert.Empty(t, w.Header().Get("Content-Length"), "length is not declared: the stream may not match the stat")
+	assert.Equal(t, "5", w.Header().Get("Content-Length"), "the length the stat reported, so the client sees size and progress")
 	assert.Equal(t, "nosniff", w.Header().Get("X-Content-Type-Options"))
 	assert.Equal(t, "sandbox", w.Header().Get("Content-Security-Policy"))
-	assert.Equal(t, "none", w.Header().Get("Accept-Ranges"))
+	assert.Equal(t, "bytes", w.Header().Get("Accept-Ranges"), "ranges are served, so an interrupted download can resume")
 	assert.Equal(t, "no-store", w.Header().Get("Cache-Control"))
 	assert.Equal(t, "exporter", w.Header().Get("X-Plugin"), "custom plugin headers pass through")
 	require.NotNil(t, files.streamOpen)
@@ -238,7 +270,8 @@ func TestServeFileRef_header_contract(t *testing.T) {
 			},
 			wantStatus: http.StatusOK,
 			wantHeaders: map[string]string{
-				"Content-Length":      "",
+				// The panel's own length wins over whatever the plugin claimed.
+				"Content-Length":      "5",
 				"Content-Disposition": `attachment; filename=a.bin; filename*=UTF-8''a.bin`,
 				"Content-Encoding":    "",
 				"Transfer-Encoding":   "",
@@ -606,4 +639,136 @@ func TestServeFileRef_path_policy(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusOK, w.Code)
 	})
+}
+
+// The stat and the stream are separate daemon calls and can disagree. The
+// declared length is the stat's, so the copy is bounded by it: a file that grew
+// in between must not push a body past the length the client was promised.
+func TestServeFileRef_a_stream_longer_than_the_stat_is_cut_to_the_declared_length(t *testing.T) {
+	t.Parallel()
+
+	files := &fakeFileService{info: csvFile(), content: "a,b\n1 and then some more"}
+	server := newTestServer(t, files, fakeChecker{allowed: true}, nil)
+	w := httptest.NewRecorder()
+
+	err := server.ServeFileRef(w, authenticatedRequest(), fileRequest(
+		&proto.FileRef{NodeId: testNodeID, Path: "/srv/gameap/servers/cs2/report.csv"},
+		nil,
+		0,
+	))
+	require.NoError(t, err)
+
+	assert.Equal(t, "5", w.Header().Get("Content-Length"))
+	assert.Equal(t, "a,b\n1", w.Body.String(), "the body is exactly as long as the header says")
+}
+
+// The other direction: a file that shrank ends the copy short. Nothing can be
+// reported to the client at that point, but the body no longer looks complete —
+// net/http fails a response that writes less than its Content-Length, which is
+// the whole reason the length is declared.
+func TestServeFileRef_a_stream_shorter_than_the_stat_does_not_look_complete(t *testing.T) {
+	t.Parallel()
+
+	files := &fakeFileService{info: csvFile(), content: "ab"}
+	server := newTestServer(t, files, fakeChecker{allowed: true}, nil)
+	w := httptest.NewRecorder()
+
+	err := server.ServeFileRef(w, authenticatedRequest(), fileRequest(
+		&proto.FileRef{NodeId: testNodeID, Path: "/srv/gameap/servers/cs2/report.csv"},
+		nil,
+		0,
+	))
+	require.NoError(t, err)
+
+	assert.Equal(t, "5", w.Header().Get("Content-Length"))
+	assert.Equal(t, "ab", w.Body.String())
+	assert.Less(t, w.Body.Len(), 5, "short of the declared length, so the transfer cannot pass as finished")
+}
+
+// Resuming an interrupted download is the whole reason ranges are served: the
+// window must reach the daemon, so the bytes before it are never pulled off the
+// node at all.
+func TestServeFileRef_serves_a_byte_range(t *testing.T) {
+	t.Parallel()
+
+	files := &fakeFileService{info: csvFile(), content: "a,b\n1"}
+	server := newTestServer(t, files, fakeChecker{allowed: true}, nil)
+	w := httptest.NewRecorder()
+	req := authenticatedRequest()
+	req.Header.Set("Range", "bytes=2-4")
+
+	err := server.ServeFileRef(w, req, fileRequest(
+		&proto.FileRef{NodeId: testNodeID, Path: "/srv/gameap/servers/cs2/report.csv"}, nil, 0,
+	))
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusPartialContent, w.Code)
+	assert.Equal(t, "bytes 2-4/5", w.Header().Get("Content-Range"))
+	assert.Equal(t, "3", w.Header().Get("Content-Length"))
+	assert.Equal(t, "b\n1", w.Body.String())
+	assert.Equal(t, uint64(2), files.rangeOffset, "the offset reached the daemon")
+	assert.Equal(t, uint64(3), files.rangeLength)
+}
+
+func TestServeFileRef_a_range_past_the_end_is_416(t *testing.T) {
+	t.Parallel()
+
+	files := &fakeFileService{info: csvFile(), content: "a,b\n1"}
+	server := newTestServer(t, files, fakeChecker{allowed: true}, nil)
+	w := httptest.NewRecorder()
+	req := authenticatedRequest()
+	req.Header.Set("Range", "bytes=500-")
+
+	err := server.ServeFileRef(w, req, fileRequest(
+		&proto.FileRef{NodeId: testNodeID, Path: "/srv/gameap/servers/cs2/report.csv"}, nil, 0,
+	))
+
+	require.Error(t, err, "the caller turns this into a 416")
+	assert.Equal(t, "bytes */5", w.Header().Get("Content-Range"), "and says how long the file really is")
+	assert.Nil(t, files.streamOpen, "nothing is read off the node for a range that cannot be served")
+}
+
+// A header the parser cannot use is not an error: RFC 9110 lets a server ignore
+// it, and answering the whole file is better than refusing the download.
+func TestServeFileRef_an_unusable_range_falls_back_to_the_whole_file(t *testing.T) {
+	t.Parallel()
+
+	files := &fakeFileService{info: csvFile(), content: "a,b\n1"}
+	server := newTestServer(t, files, fakeChecker{allowed: true}, nil)
+	w := httptest.NewRecorder()
+	req := authenticatedRequest()
+	req.Header.Set("Range", "bytes=0-9,20-29")
+
+	err := server.ServeFileRef(w, req, fileRequest(
+		&proto.FileRef{NodeId: testNodeID, Path: "/srv/gameap/servers/cs2/report.csv"}, nil, 0,
+	))
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "a,b\n1", w.Body.String())
+	assert.Empty(t, w.Header().Get("Content-Range"))
+	assert.Zero(t, files.rangeOffset, "the ranged read was never opened")
+}
+
+// A plugin that chose its own status said something about the response that the
+// transfer layer must not rewrite into a 206.
+func TestServeFileRef_a_range_is_ignored_when_the_plugin_set_its_own_status(t *testing.T) {
+	t.Parallel()
+
+	files := &fakeFileService{info: csvFile(), content: "a,b\n1"}
+	server := newTestServer(t, files, fakeChecker{allowed: true}, nil)
+	w := httptest.NewRecorder()
+	req := authenticatedRequest()
+	req.Header.Set("Range", "bytes=2-4")
+
+	err := server.ServeFileRef(w, req, fileRequest(
+		&proto.FileRef{NodeId: testNodeID, Path: "/srv/gameap/servers/cs2/report.csv"},
+		nil,
+		http.StatusCreated,
+	))
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusCreated, w.Code)
+	assert.Equal(t, "a,b\n1", w.Body.String())
+	assert.Empty(t, w.Header().Get("Content-Range"))
 }

--- a/internal/application/container.go
+++ b/internal/application/container.go
@@ -2337,6 +2337,7 @@ func (c *Container) corePluginLibraryFactories(guard *hostlibrary.Guard) []pkgpl
 			&lazyArchiveEvents{container: c},
 			guard,
 			hostlibrary.WithNodeFSMaxInlineBytes(c.config.Plugin.NodeFS.MaxInline.Uint64()),
+			hostlibrary.WithNodeFSPathPolicy(c.PluginPathPolicy()),
 		),
 		// Per-plugin: writes are gated on manage_servers / node_commands,
 		// rate limited and audited with the plugin as the actor.

--- a/internal/daemon/file.go
+++ b/internal/daemon/file.go
@@ -24,8 +24,15 @@ import (
 )
 
 const (
-	smallFileThreshold     = 1 * 1024 * 1024 // 1MB
-	chunkSize              = 64 * 1024       // 64KB
+	smallFileThreshold = 1 * 1024 * 1024 // 1MB
+	chunkSize          = 64 * 1024       // 64KB
+	// rangeChunkSize is what a ranged read asks for per round trip. It is much
+	// larger than chunkSize because a range is how a multi-gigabyte download
+	// resumes: at 64 KiB, finishing the last 20 GiB would take some 300 000
+	// round trips and their latency would dwarf the transfer. The ceiling is
+	// the gRPC message limit (GRPC_MAX_RECV_MSG_SIZE, 10 MiB by default), and
+	// this leaves room for framing under a lowered one.
+	rangeChunkSize         = 4 << 20 // 4MiB
 	transferPrefix         = "transfers/"
 	capabilityFileTransfer = "file_transfer"
 	s3PollInterval         = 200 * time.Millisecond
@@ -154,9 +161,26 @@ func (s *FileService) DownloadLimited(
 	filePath string,
 	limit uint64,
 ) ([]byte, error) {
+	return s.DownloadRange(ctx, node, filePath, 0, limit)
+}
+
+// DownloadRange reads at most limit bytes starting at offset (limit 0 = to the
+// end of the file). It is how a caller reads a file the inline cap will not let
+// it take in one piece: the window, not the file, is what has to fit.
+//
+// The daemon has taken an offset on this path all along — both routes carried a
+// hard-coded 0 — so nothing on the node had to change for this.
+func (s *FileService) DownloadRange(
+	ctx context.Context,
+	node *domain.Node,
+	filePath string,
+	offset uint64,
+	limit uint64,
+) ([]byte, error) {
 	nodeID := uint64(node.ID)
 	relPath := stripWorkPath(node.WorkPath, filePath)
 	length := int64(min(limit, math.MaxInt64)) //nolint:gosec // G115: clamped to MaxInt64 just before
+	start := int64(min(offset, math.MaxInt64)) //nolint:gosec // G115: clamped to MaxInt64 just before
 
 	local, err := s.resolveRoute(nodeID)
 	if err != nil {
@@ -164,7 +188,7 @@ func (s *FileService) DownloadLimited(
 	}
 
 	if local {
-		resp, readErr := s.gateway.RequestFileRead(ctx, nodeID, relPath, 0, length)
+		resp, readErr := s.gateway.RequestFileRead(ctx, nodeID, relPath, start, length)
 		if readErr != nil {
 			return nil, errors.WithMessage(readErr, "file read request")
 		}
@@ -180,7 +204,7 @@ func (s *FileService) DownloadLimited(
 		return resp.Content, nil
 	}
 
-	result, err := s.dispatcher.DispatchFileRead(ctx, nodeID, relPath, 0, length)
+	result, err := s.dispatcher.DispatchFileRead(ctx, nodeID, relPath, start, length)
 	if err != nil {
 		return nil, errors.WithMessage(err, "dispatched file read")
 	}
@@ -216,6 +240,134 @@ func (s *FileService) DownloadStream(
 	}
 
 	return s.downloadStreamRemote(ctx, nodeID, relPath)
+}
+
+// DownloadStreamRange streams at most length bytes starting at offset
+// (length 0 = to the end of the file).
+//
+// Unlike DownloadStream it always reads in chunks, on both routes, and never
+// uses the transfer task the plain stream prefers: FileDownloadTask carries no
+// start offset, so serving a range through it would mean pulling everything
+// before the offset off the node and discarding it — the exact transfer a
+// resumed download exists to avoid.
+func (s *FileService) DownloadStreamRange(
+	ctx context.Context,
+	node *domain.Node,
+	filePath string,
+	offset uint64,
+	length uint64,
+) (io.ReadCloser, error) {
+	nodeID := uint64(node.ID)
+	relPath := stripWorkPath(node.WorkPath, filePath)
+
+	local, err := s.resolveRoute(nodeID)
+	if err != nil {
+		return nil, err
+	}
+
+	start := int64(min(offset, math.MaxInt64))     //nolint:gosec // G115: clamped to MaxInt64 just before
+	remaining := int64(min(length, math.MaxInt64)) //nolint:gosec // G115: clamped to MaxInt64 just before
+
+	return s.chunkedRange(ctx, nodeID, relPath, start, remaining, local), nil
+}
+
+// chunkedRange is the reader behind DownloadStreamRange: one chunk-sized read
+// per turn, from whichever route owns the daemon session, until the window is
+// full or the node answers short.
+func (s *FileService) chunkedRange(
+	ctx context.Context, nodeID uint64, path string, offset, remaining int64, local bool,
+) io.ReadCloser {
+	pr, pw := io.Pipe()
+	// remaining == 0 means "to the end"; anything else counts down to zero.
+	unbounded := remaining == 0
+
+	go func() {
+		defer pw.Close()
+
+		for unbounded || remaining > 0 {
+			select {
+			case <-ctx.Done():
+				pw.CloseWithError(ctx.Err())
+
+				return
+			default:
+			}
+
+			want := int64(rangeChunkSize)
+			if !unbounded && remaining < want {
+				want = remaining
+			}
+
+			content, err := s.readChunk(ctx, nodeID, path, offset, want, local)
+			if err != nil {
+				pw.CloseWithError(err)
+
+				return
+			}
+
+			if len(content) == 0 {
+				return
+			}
+
+			if _, err := pw.Write(content); err != nil {
+				return
+			}
+
+			offset += int64(len(content))
+			if !unbounded {
+				remaining -= int64(len(content))
+			}
+
+			// A short answer is the end of the file: the node had less than
+			// the window asked for.
+			if int64(len(content)) < want {
+				return
+			}
+		}
+	}()
+
+	return pr
+}
+
+// readChunk reads one window through whichever route owns the session. The
+// remote route may stage a large answer in storage instead of inlining it;
+// at chunk size that is unusual, but it costs nothing to honour.
+func (s *FileService) readChunk(
+	ctx context.Context, nodeID uint64, path string, offset, length int64, local bool,
+) ([]byte, error) {
+	if local {
+		resp, err := s.gateway.RequestFileRead(ctx, nodeID, path, offset, length)
+		if err != nil {
+			return nil, errors.WithMessage(err, "gateway ranged read")
+		}
+
+		if !resp.Success {
+			if readErr := daemonFileError("file read", resp.Error); readErr != nil {
+				return nil, readErr
+			}
+
+			return nil, errors.Errorf("gateway ranged read: %s", resp.Error)
+		}
+
+		return resp.Content, nil
+	}
+
+	result, err := s.dispatcher.DispatchFileRead(ctx, nodeID, path, offset, length)
+	if err != nil {
+		return nil, errors.WithMessage(err, "dispatched ranged read")
+	}
+
+	if result.Content != nil {
+		return result.Content, nil
+	}
+
+	content, err := s.storage.Read(ctx, result.StoragePath)
+	if err != nil {
+		return nil, errors.WithMessage(err, "reading transferred range from storage")
+	}
+	_ = s.storage.Delete(context.Background(), result.StoragePath)
+
+	return content, nil
 }
 
 func (s *FileService) downloadStreamLocal(ctx context.Context, nodeID uint64, path string) (io.ReadCloser, error) {

--- a/internal/plugin/hostlibrary/contracts.go
+++ b/internal/plugin/hostlibrary/contracts.go
@@ -32,6 +32,12 @@ type NodeFileService interface {
 	// DownloadLimited reads at most limit bytes from the start of the file;
 	// 0 reads the whole file.
 	DownloadLimited(ctx context.Context, node *domain.Node, filePath string, limit uint64) ([]byte, error)
+	// DownloadRange reads at most limit bytes starting at offset; limit 0 reads
+	// to the end of the file. It is what lets a plugin read a file larger than
+	// the inline cap, one window at a time.
+	DownloadRange(
+		ctx context.Context, node *domain.Node, filePath string, offset, limit uint64,
+	) ([]byte, error)
 	Upload(
 		ctx context.Context,
 		node *domain.Node,

--- a/internal/plugin/hostlibrary/guard_test.go
+++ b/internal/plugin/hostlibrary/guard_test.go
@@ -485,6 +485,7 @@ func TestHostRPCPolicies_cover_generated_exports(t *testing.T) {
 		ModuleServerSettings: "serversettings",
 		ModuleHost:           "host",
 		ModuleSSH:            "ssh",
+		ModuleNodes:          "nodes",
 	}
 
 	// Read-only functions of mixed modules that deliberately need no grant,
@@ -498,6 +499,8 @@ func TestHostRPCPolicies_cover_generated_exports(t *testing.T) {
 		{ModuleHost, "get_config"}:                     {},
 		{ModuleHost, "get_host_info"}:                  {},
 		{ModuleHost, "report_status"}:                  {},
+		{ModuleNodes, "find_nodes"}:                    {},
+		{ModuleNodes, "get_node"}:                      {},
 	}
 
 	for module, dir := range modules {
@@ -547,6 +550,10 @@ func TestPermissionForImport(t *testing.T) {
 		{name: "nodefs", module: ModuleNodeFS, export: "upload", wantPerm: domain.PluginPermissionFiles, wantOK: true},
 		{name: "http_has_no_grant", module: ModuleHTTP, export: "fetch", wantOK: false},
 		{name: "read_only_module", module: "gameap-users", export: "get_user", wantOK: false},
+		// gameap-nodes gained write operations; a plugin that retires a node
+		// must show up as needing manage_nodes in the dry-run and the admin UI.
+		{name: "nodes_write", module: ModuleNodes, export: "delete_node", wantPerm: domain.PluginPermissionManageNodes, wantOK: true},
+		{name: "nodes_read", module: ModuleNodes, export: "get_node", wantOK: false},
 		{name: "unknown_function", module: ModuleNodeCmd, export: "nope", wantOK: false},
 	}
 

--- a/internal/plugin/hostlibrary/modules_guard_test.go
+++ b/internal/plugin/hostlibrary/modules_guard_test.go
@@ -113,7 +113,7 @@ func TestNodeCmdService_requires_node_commands(t *testing.T) {
 			t.Parallel()
 
 			guard := NewGuard(tt.grants, WithGuardAudit(recorder)).For(testPluginID)
-			svc := NewNodeCmdService(&mockCommandService{}, repo, guard)
+			svc := NewNodeCmdService(testPluginID, &mockCommandService{}, repo, guard)
 
 			resp, err := svc.ExecuteCommand(context.Background(), &nodecmd.ExecuteCommandRequest{
 				NodeId: 1, Command: "uptime",
@@ -138,7 +138,7 @@ func TestNodeCmdService_audit_never_carries_the_command(t *testing.T) {
 	repo := setupNodeFSRepo(seedTestNode)
 	recorder := &auditRecorder{}
 	guard := NewGuard(grantSet{domain.PluginPermissionNodeCommands: true}, WithGuardAudit(recorder)).For(testPluginID)
-	svc := NewNodeCmdService(&mockCommandService{}, repo, guard)
+	svc := NewNodeCmdService(testPluginID, &mockCommandService{}, repo, guard)
 
 	resp, err := svc.ExecuteCommand(context.Background(), &nodecmd.ExecuteCommandRequest{
 		NodeId: 1, Command: "mysql -psecret-password", WorkDir: new("/srv"),

--- a/internal/plugin/hostlibrary/nodecmd.go
+++ b/internal/plugin/hostlibrary/nodecmd.go
@@ -19,6 +19,7 @@ import (
 // itself is not written to the audit stream (it may carry credentials); the
 // node, working directory and exit code are.
 type NodeCmdServiceImpl struct {
+	pluginID       uint64
 	commandService NodeCommandService
 	nodeRepo       repositories.NodeRepository
 	guard          *PluginGuard
@@ -40,12 +41,14 @@ func WithNodeCmdPathPolicy(policy *PathPolicy) NodeCmdOption {
 }
 
 func NewNodeCmdService(
+	pluginID uint64,
 	commandService NodeCommandService,
 	nodeRepo repositories.NodeRepository,
 	guard *PluginGuard,
 	opts ...NodeCmdOption,
 ) *NodeCmdServiceImpl {
 	service := &NodeCmdServiceImpl{
+		pluginID:       pluginID,
 		commandService: commandService,
 		nodeRepo:       nodeRepo,
 		guard:          guard,
@@ -67,7 +70,7 @@ func (s *NodeCmdServiceImpl) checkWorkDir(ctx context.Context, node *domain.Node
 		return ""
 	}
 
-	scope, err := s.policy.ScopeFor(ctx, node)
+	scope, err := s.policy.ScopeFor(ctx, node, s.pluginID)
 	if err != nil {
 		slog.ErrorContext(ctx, "failed to resolve the node path policy, refusing the command",
 			slog.Uint64("node_id", uint64(node.ID)),
@@ -176,6 +179,6 @@ func NewNodeCmdHostLibraryFactory(
 
 func (f *NodeCmdHostLibraryFactory) Create(pluginID uint64) pkgplugin.HostLibrary {
 	return &NodeCmdHostLibrary{
-		impl: NewNodeCmdService(f.commandService, f.nodeRepo, f.guard.For(pluginID), f.opts...),
+		impl: NewNodeCmdService(pluginID, f.commandService, f.nodeRepo, f.guard.For(pluginID), f.opts...),
 	}
 }

--- a/internal/plugin/hostlibrary/nodecmd_test.go
+++ b/internal/plugin/hostlibrary/nodecmd_test.go
@@ -45,10 +45,10 @@ func newNodeCmdService(
 	cmd NodeCommandService, repo *inmemory.NodeRepository, repoFails bool,
 ) *NodeCmdServiceImpl {
 	if repoFails {
-		return NewNodeCmdService(cmd, &errNodeRepository{NodeRepository: repo}, allowAllGuard(testPluginID))
+		return NewNodeCmdService(testPluginID, cmd, &errNodeRepository{NodeRepository: repo}, allowAllGuard(testPluginID))
 	}
 
-	return NewNodeCmdService(cmd, repo, allowAllGuard(testPluginID))
+	return NewNodeCmdService(testPluginID, cmd, repo, allowAllGuard(testPluginID))
 }
 
 func TestNodeCmdService_ExecuteCommand(t *testing.T) {
@@ -223,7 +223,7 @@ func TestNodeCmdService_ExecuteCommand_ForwardsCommandAndWorkDir(t *testing.T) {
 			return &daemon.CommandResult{Output: "ok", ExitCode: 0}, nil
 		},
 	}
-	svc := NewNodeCmdService(cmdSvc, repo, allowAllGuard(testPluginID))
+	svc := NewNodeCmdService(testPluginID, cmdSvc, repo, allowAllGuard(testPluginID))
 
 	// ACT
 	resp, err := svc.ExecuteCommand(context.Background(), &nodecmd.ExecuteCommandRequest{
@@ -255,7 +255,7 @@ func TestNodeCmdService_ExecuteCommand_OmitsWorkDirOptionWhenUnset(t *testing.T)
 			return &daemon.CommandResult{Output: "ok", ExitCode: 0}, nil
 		},
 	}
-	svc := NewNodeCmdService(cmdSvc, repo, allowAllGuard(testPluginID))
+	svc := NewNodeCmdService(testPluginID, cmdSvc, repo, allowAllGuard(testPluginID))
 
 	// ACT
 	_, err := svc.ExecuteCommand(context.Background(), &nodecmd.ExecuteCommandRequest{

--- a/internal/plugin/hostlibrary/nodefs.go
+++ b/internal/plugin/hostlibrary/nodefs.go
@@ -95,7 +95,7 @@ func (s *NodeFSServiceImpl) authorize(ctx context.Context, export string) (bool,
 // paths falls outside the node path policy; the answer is the message to
 // hand the guest, "" when every path is allowed.
 func (s *NodeFSServiceImpl) checkPaths(ctx context.Context, export string, node *domain.Node, paths ...string) string {
-	scope, err := s.policy.ScopeFor(ctx, node)
+	scope, err := s.policy.ScopeFor(ctx, node, s.pluginID)
 	if err != nil {
 		slog.ErrorContext(ctx, "failed to resolve the node path policy, refusing the call",
 			slog.Uint64("plugin_id", s.pluginID),
@@ -289,60 +289,98 @@ func (s *NodeFSServiceImpl) Download(
 		return &nodefs.DownloadResponse{Error: new(msg)}, nil
 	}
 
-	if msg := s.checkInlineDownloadSize(ctx, node, req.Path); msg != "" {
+	// Stat only when the answer depends on it: an inline limit to check the
+	// file against, or a window to place inside the file. An uncapped
+	// whole-file read still costs one daemon round trip, as it always did.
+	var size uint64
+
+	if s.maxInlineBytes > 0 || req.Offset > 0 || req.Length > 0 {
+		info, statErr := s.fileService.GetFileInfo(ctx, node, req.Path)
+		if statErr != nil {
+			return &nodefs.DownloadResponse{Error: new("stat failed: " + statErr.Error())}, nil
+		}
+
+		if info == nil {
+			return &nodefs.DownloadResponse{Error: new("file not found")}, nil
+		}
+
+		size = info.Size
+
+		// Reading at or past the end is how a caller paging through a file
+		// finds out it is done, so it answers empty rather than failing.
+		if req.Offset >= size {
+			return &nodefs.DownloadResponse{Offset: req.Offset, TotalSize: size}, nil
+		}
+	}
+
+	length, msg := s.downloadWindow(req, size)
+	if msg != "" {
 		return &nodefs.DownloadResponse{Error: new(msg)}, nil
 	}
 
-	// The stat above is advisory (the file may have grown since), so the
-	// read itself stops one byte past the cap: the guest never receives
-	// more than the cap and the panel never buffers much more than it.
-	content, err := s.fileService.DownloadLimited(ctx, node, req.Path, s.inlineReadLimit())
+	// The stat above is advisory (the file may have grown since), so the read
+	// itself stops one byte past what was allowed: the guest never receives
+	// more than the limit and the panel never buffers much more than it.
+	content, err := s.fileService.DownloadRange(ctx, node, req.Path, req.Offset, readLimit(length))
 	if err != nil {
 		return &nodefs.DownloadResponse{Error: new(err.Error())}, nil
 	}
 
-	if s.maxInlineBytes > 0 && uint64(len(content)) > s.maxInlineBytes {
+	if length > 0 && uint64(len(content)) > length {
 		return &nodefs.DownloadResponse{Error: new(fmt.Sprintf(
 			"file too large: content exceeds the inline download limit of %d bytes", s.maxInlineBytes))}, nil
 	}
 
-	return &nodefs.DownloadResponse{Content: content}, nil
+	return &nodefs.DownloadResponse{Content: content, Offset: req.Offset, TotalSize: size}, nil
 }
 
-// inlineReadLimit is how much Download asks the node for: one byte past
-// the cap, enough to tell an oversized file from one exactly at the limit;
-// without a cap the whole file.
-func (s *NodeFSServiceImpl) inlineReadLimit() uint64 {
-	if s.maxInlineBytes == 0 {
+// downloadWindow resolves how many bytes a download may return, or the message
+// that refuses it. It answers 0 for "no bound", which only an uncapped panel
+// can produce.
+//
+// A request that names neither an offset nor a length is the old whole-file
+// read and keeps its old answer: a file past the inline limit is refused
+// outright rather than silently truncated, because a caller that asked for the
+// file and got part of it has no way to tell. A request that names a window has
+// said what it wants, so only the window has to fit.
+func (s *NodeFSServiceImpl) downloadWindow(req *nodefs.DownloadRequest, size uint64) (uint64, string) {
+	if req.Offset == 0 && req.Length == 0 {
+		if s.maxInlineBytes > 0 && size > s.maxInlineBytes {
+			return 0, fmt.Sprintf(
+				"file too large: %d bytes exceeds the inline download limit of %d bytes"+
+					" (read it in windows with offset/length)",
+				size, s.maxInlineBytes)
+		}
+
+		return s.maxInlineBytes, ""
+	}
+
+	if req.Length == 0 {
+		if s.maxInlineBytes == 0 {
+			return 0, ""
+		}
+
+		return min(s.maxInlineBytes, size-min(size, req.Offset)), ""
+	}
+
+	if s.maxInlineBytes > 0 && req.Length > s.maxInlineBytes {
+		return 0, fmt.Sprintf(
+			"window too large: %d bytes exceeds the inline download limit of %d bytes",
+			req.Length, s.maxInlineBytes)
+	}
+
+	return req.Length, ""
+}
+
+// readLimit is what the node is asked for: one byte past what the answer may
+// contain, enough to tell a window that is exactly full from one that was cut.
+// Zero stays zero — no bound at all.
+func readLimit(length uint64) uint64 {
+	if length == 0 {
 		return 0
 	}
 
-	return s.maxInlineBytes + 1
-}
-
-// checkInlineDownloadSize refuses a download that would exceed the inline
-// cap before a single byte is read: the whole file would otherwise be
-// buffered in panel memory. It answers a response-level message or "".
-func (s *NodeFSServiceImpl) checkInlineDownloadSize(ctx context.Context, node *domain.Node, filePath string) string {
-	if s.maxInlineBytes == 0 {
-		return ""
-	}
-
-	info, err := s.fileService.GetFileInfo(ctx, node, filePath)
-	if err != nil {
-		return "stat failed: " + err.Error()
-	}
-
-	if info == nil {
-		return "file not found"
-	}
-
-	if info.Size > s.maxInlineBytes {
-		return fmt.Sprintf("file too large: %d bytes exceeds the inline download limit of %d bytes",
-			info.Size, s.maxInlineBytes)
-	}
-
-	return ""
+	return length + 1
 }
 
 func (s *NodeFSServiceImpl) Upload(

--- a/internal/plugin/hostlibrary/nodefs.go
+++ b/internal/plugin/hostlibrary/nodefs.go
@@ -327,11 +327,29 @@ func (s *NodeFSServiceImpl) Download(
 	}
 
 	if length > 0 && uint64(len(content)) > length {
-		return &nodefs.DownloadResponse{Error: new(fmt.Sprintf(
-			"file too large: content exceeds the inline download limit of %d bytes", s.maxInlineBytes))}, nil
+		// A whole-file read asked for the file, not a prefix of it, and has no
+		// way to tell a truncation from the real thing — the file grew past the
+		// limit since the stat, so the answer is a refusal. A caller that named
+		// a window said how much it wants, and getting the whole window back is
+		// the ordinary case: the extra byte the read took is simply dropped.
+		if wholeFileRead(req) {
+			return &nodefs.DownloadResponse{Error: new(fmt.Sprintf(
+				"file too large: content exceeds the inline download limit of %d bytes", s.maxInlineBytes))}, nil
+		}
+
+		content = content[:length]
 	}
 
+	// len(Content) is the bound that was applied, Offset is echoed and
+	// TotalSize is set on every windowed read, so a caller paging through a
+	// file reads on while Offset+len(Content) < TotalSize.
 	return &nodefs.DownloadResponse{Content: content, Offset: req.Offset, TotalSize: size}, nil
+}
+
+// wholeFileRead is the request that names no window: it asked for the file, not
+// a piece of it.
+func wholeFileRead(req *nodefs.DownloadRequest) bool {
+	return req.Offset == 0 && req.Length == 0
 }
 
 // downloadWindow resolves how many bytes a download may return, or the message
@@ -342,9 +360,10 @@ func (s *NodeFSServiceImpl) Download(
 // read and keeps its old answer: a file past the inline limit is refused
 // outright rather than silently truncated, because a caller that asked for the
 // file and got part of it has no way to tell. A request that names a window has
-// said what it wants, so only the window has to fit.
+// said what it wants, so only the window has to fit — and is served exactly
+// that window, cut to the bound this returns.
 func (s *NodeFSServiceImpl) downloadWindow(req *nodefs.DownloadRequest, size uint64) (uint64, string) {
-	if req.Offset == 0 && req.Length == 0 {
+	if wholeFileRead(req) {
 		if s.maxInlineBytes > 0 && size > s.maxInlineBytes {
 			return 0, fmt.Sprintf(
 				"file too large: %d bytes exceeds the inline download limit of %d bytes"+

--- a/internal/plugin/hostlibrary/nodefs_limits_test.go
+++ b/internal/plugin/hostlibrary/nodefs_limits_test.go
@@ -229,6 +229,7 @@ func TestNodeFSService_Download_windowed(t *testing.T) {
 		length     uint64
 		wantOffset uint64
 		wantRead   uint64 // the limit handed to the node; 0 = no read expected
+		wantServed uint64 // the bytes that reach the guest
 		wantError  string
 	}{
 		{
@@ -239,7 +240,7 @@ func TestNodeFSService_Download_windowed(t *testing.T) {
 		{
 			name:   "a_window_inside_the_cap_is_served",
 			offset: 4096, length: 512,
-			wantOffset: 4096, wantRead: 513,
+			wantOffset: 4096, wantRead: 513, wantServed: 512,
 		},
 		{
 			name:   "a_window_larger_than_the_cap_is_refused",
@@ -249,7 +250,12 @@ func TestNodeFSService_Download_windowed(t *testing.T) {
 		{
 			name:   "an_open_ended_window_is_cut_to_the_cap",
 			offset: 4096, length: 0,
-			wantOffset: 4096, wantRead: inlineCap + 1,
+			wantOffset: 4096, wantRead: inlineCap + 1, wantServed: inlineCap,
+		},
+		{
+			name:   "the_last_window_is_served_short",
+			offset: fileSize - 256, length: 512,
+			wantOffset: fileSize - 256, wantRead: 513, wantServed: 256,
 		},
 		{
 			name:   "a_window_past_the_end_answers_empty",
@@ -275,7 +281,14 @@ func TestNodeFSService_Download_windowed(t *testing.T) {
 					gotOffset.Store(offset)
 					gotLimit.Store(limit)
 
-					return []byte("window"), nil
+					// What the node does, and what the trimming depends on: at
+					// most limit bytes from offset, limit 0 reading to the end.
+					available := fileSize - min(fileSize, offset)
+					if limit == 0 {
+						limit = available
+					}
+
+					return make([]byte, min(limit, available)), nil
 				},
 			}
 			svc := newCappedNodeFSService(fs, inlineCap)
@@ -296,6 +309,8 @@ func TestNodeFSService_Download_windowed(t *testing.T) {
 			require.Nil(t, resp.Error)
 			assert.Equal(t, tt.wantOffset, resp.Offset, "the offset is echoed back")
 			assert.Equal(t, uint64(fileSize), resp.TotalSize, "so the caller knows when to stop paging")
+			assert.Equal(t, tt.wantServed, uint64(len(resp.Content)),
+				"the guest is served the window it asked for, never the extra byte the read took")
 
 			if tt.wantRead == 0 {
 				assert.Zero(t, reads.Load(), "reading past the end costs no round trip")

--- a/internal/plugin/hostlibrary/nodefs_limits_test.go
+++ b/internal/plugin/hostlibrary/nodefs_limits_test.go
@@ -212,3 +212,102 @@ func TestNodeFSHostLibraryFactory_passes_options(t *testing.T) {
 	assert.Equal(t, uint64(123), lib.impl.maxInlineBytes)
 	assert.Equal(t, uint64(42), lib.impl.pluginID)
 }
+
+// A file past the inline limit used to be unreadable altogether. Naming a
+// window makes it readable a piece at a time: only the window has to fit.
+func TestNodeFSService_Download_windowed(t *testing.T) {
+	t.Parallel()
+
+	const (
+		inlineCap = 1024
+		fileSize  = 10_000
+	)
+
+	tests := []struct {
+		name       string
+		offset     uint64
+		length     uint64
+		wantOffset uint64
+		wantRead   uint64 // the limit handed to the node; 0 = no read expected
+		wantError  string
+	}{
+		{
+			name:   "a_whole_file_past_the_cap_is_still_refused",
+			offset: 0, length: 0,
+			wantError: "file too large",
+		},
+		{
+			name:   "a_window_inside_the_cap_is_served",
+			offset: 4096, length: 512,
+			wantOffset: 4096, wantRead: 513,
+		},
+		{
+			name:   "a_window_larger_than_the_cap_is_refused",
+			offset: 0, length: inlineCap + 1,
+			wantError: "window too large",
+		},
+		{
+			name:   "an_open_ended_window_is_cut_to_the_cap",
+			offset: 4096, length: 0,
+			wantOffset: 4096, wantRead: inlineCap + 1,
+		},
+		{
+			name:   "a_window_past_the_end_answers_empty",
+			offset: fileSize, length: 512,
+			wantOffset: fileSize,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var reads atomic.Int32
+			var gotOffset, gotLimit atomic.Uint64
+			fs := &mockFileService{
+				getFileInfoFunc: func(_ context.Context, _ *domain.Node, _ string) (*daemon.FileDetails, error) {
+					return &daemon.FileDetails{Name: "big.bin", Size: fileSize}, nil
+				},
+				downloadRangeFunc: func(
+					_ context.Context, _ *domain.Node, _ string, offset, limit uint64,
+				) ([]byte, error) {
+					reads.Add(1)
+					gotOffset.Store(offset)
+					gotLimit.Store(limit)
+
+					return []byte("window"), nil
+				},
+			}
+			svc := newCappedNodeFSService(fs, inlineCap)
+
+			resp, err := svc.Download(context.Background(), &nodefs.DownloadRequest{
+				NodeId: 1, Path: "/home/big.bin", Offset: tt.offset, Length: tt.length,
+			})
+			require.NoError(t, err)
+
+			if tt.wantError != "" {
+				require.NotNil(t, resp.Error)
+				assert.Contains(t, *resp.Error, tt.wantError)
+				assert.Zero(t, reads.Load(), "a refused window never reaches the node")
+
+				return
+			}
+
+			require.Nil(t, resp.Error)
+			assert.Equal(t, tt.wantOffset, resp.Offset, "the offset is echoed back")
+			assert.Equal(t, uint64(fileSize), resp.TotalSize, "so the caller knows when to stop paging")
+
+			if tt.wantRead == 0 {
+				assert.Zero(t, reads.Load(), "reading past the end costs no round trip")
+				assert.Empty(t, resp.Content)
+
+				return
+			}
+
+			require.Equal(t, int32(1), reads.Load())
+			assert.Equal(t, tt.wantOffset, gotOffset.Load())
+			assert.Equal(t, tt.wantRead, gotLimit.Load(),
+				"the node is asked for one byte past the window, to tell full from cut")
+		})
+	}
+}

--- a/internal/plugin/hostlibrary/nodefs_test.go
+++ b/internal/plugin/hostlibrary/nodefs_test.go
@@ -44,6 +44,9 @@ type mockFileService struct {
 	hashFunc        func(
 		ctx context.Context, node *domain.Node, paths []string, algorithm proto.HashAlgorithm,
 	) (*proto.HashResult, error)
+	downloadRangeFunc func(
+		ctx context.Context, node *domain.Node, path string, offset, limit uint64,
+	) ([]byte, error)
 }
 
 func (m *mockFileService) ReadDir(ctx context.Context, node *domain.Node, path string) ([]*daemon.FileInfo, error) {
@@ -88,6 +91,16 @@ func (m *mockFileService) DownloadLimited(
 	}
 
 	return nil, nil
+}
+
+func (m *mockFileService) DownloadRange(
+	ctx context.Context, node *domain.Node, path string, offset, limit uint64,
+) ([]byte, error) {
+	if m.downloadRangeFunc != nil {
+		return m.downloadRangeFunc(ctx, node, path, offset, limit)
+	}
+
+	return m.DownloadLimited(ctx, node, path, limit)
 }
 
 func (m *mockFileService) Upload(

--- a/internal/plugin/hostlibrary/pathpolicy.go
+++ b/internal/plugin/hostlibrary/pathpolicy.go
@@ -8,8 +8,30 @@ import (
 
 	"github.com/gameap/gameap/internal/domain"
 	"github.com/gameap/gameap/internal/filters"
+	pkgplugin "github.com/gameap/gameap/pkg/plugin"
 	"github.com/pkg/errors"
 )
+
+// PluginServiceRoot is the directory under a node's work path that holds the
+// working files of plugins, one subdirectory per plugin.
+const PluginServiceRoot = ".plugins"
+
+// PluginServiceDir is where one plugin keeps its own working files on a node:
+// <work_path>/.plugins/<compact plugin id>. Request files, staged results and
+// anything else a plugin needs a node-side scratch space for belong here, and
+// nowhere else — this is the one place outside the game servers' own
+// directories that the restricted path policies keep open, and it is opened
+// only to the plugin whose id names it.
+//
+// A plugin id of 0 is a transient load (the upload dry-run), which owns no
+// directory: the answer is empty and the caller adds no root.
+func PluginServiceDir(workPath string, pluginID uint64) string {
+	if pluginID == 0 || strings.TrimSpace(workPath) == "" {
+		return ""
+	}
+
+	return joinNodePath(workPath, PluginServiceRoot+"/"+pkgplugin.CompactPluginID(domain.Uint64ID(pluginID)))
+}
 
 // PathPolicyMode selects which node paths gameap-nodefs (and the work_dir of
 // gameap-nodecmd) may name.
@@ -123,7 +145,7 @@ type PathScope struct {
 // the work path in node_workpath, the server directories (plus the extra
 // roots) in server_dirs. The server lookup happens once per host call, so a
 // call naming several paths (copy, hash, archive) pays for it once.
-func (p *PathPolicy) ScopeFor(ctx context.Context, node *domain.Node) (*PathScope, error) {
+func (p *PathPolicy) ScopeFor(ctx context.Context, node *domain.Node, pluginID uint64) (*PathScope, error) {
 	if p == nil || node == nil {
 		return &PathScope{mode: PathPolicyUnrestricted}, nil
 	}
@@ -141,6 +163,15 @@ func (p *PathPolicy) ScopeFor(ctx context.Context, node *domain.Node) (*PathScop
 
 	scope.workPath = workPath
 	scope.roots = append(scope.roots, p.extraRoots...)
+
+	// Every restricted mode keeps the plugin's own service directory open.
+	// Without it a plugin cannot stage so much as a request file, and the
+	// operator would have to name each plugin's directory by hand — as an
+	// absolute path, on every node, which is not something the work paths of a
+	// mixed fleet allow.
+	if serviceDir := PluginServiceDir(workPath, pluginID); serviceDir != "" {
+		scope.roots = append(scope.roots, serviceDir)
+	}
 
 	switch p.mode {
 	case PathPolicyNodeWorkPath:

--- a/internal/plugin/hostlibrary/pathpolicy_modules_test.go
+++ b/internal/plugin/hostlibrary/pathpolicy_modules_test.go
@@ -169,7 +169,7 @@ func TestNodeCmdService_work_dir_policy(t *testing.T) {
 		return &daemon.CommandResult{}, nil
 	}}
 	guard := NewGuard(grantSet{domain.PluginPermissionNodeCommands: true}, WithGuardAudit(recorder)).For(testPluginID)
-	svc := NewNodeCmdService(cmd, repo, guard, WithNodeCmdPathPolicy(workPathPolicy(t)))
+	svc := NewNodeCmdService(testPluginID, cmd, repo, guard, WithNodeCmdPathPolicy(workPathPolicy(t)))
 
 	resp, err := svc.ExecuteCommand(context.Background(), &nodecmd.ExecuteCommandRequest{
 		NodeId: 1, Command: "ls", WorkDir: new("/etc"),
@@ -235,4 +235,30 @@ func TestNodeFSService_archive_without_a_base_path_is_not_refused(t *testing.T) 
 	require.Len(t, calls, 1)
 	require.NotNil(t, calls[0].create)
 	assert.Empty(t, calls[0].create.BasePath, "the empty base path reaches the daemon unchanged")
+}
+
+// The production wiring reaches gameap-nodefs through the factory, not through
+// NewNodeFSService, and the factory silently defaults to the unrestricted
+// policy when the option is not passed. That is exactly how the policy came to
+// be enforced on gameap-nodecmd and on file references but not on gameap-nodefs
+// itself, so the propagation is pinned here rather than left to the direct
+// constructor the other tests use.
+func TestNodeFSHostLibraryFactory_propagates_the_path_policy(t *testing.T) {
+	t.Parallel()
+
+	repo := setupNodeFSRepo(seedWorkPathNode)
+	fs := refusingFileService(t)
+
+	factory := NewNodeFSHostLibraryFactory(fs, repo, newMockArchiveService(), &mockRegistrar{},
+		NewGuard(grantSet{domain.PluginPermissionFiles: true}),
+		WithNodeFSPathPolicy(workPathPolicy(t)))
+
+	library, ok := factory.Create(testPluginID).(*NodeFSHostLibrary)
+	require.True(t, ok, "the factory builds a NodeFSHostLibrary")
+
+	resp, err := library.impl.ReadDir(context.Background(),
+		&nodefs.ReadDirRequest{NodeId: 1, Path: "/etc/shadow"})
+	require.NoError(t, err)
+	require.NotNil(t, resp.Error, "a path outside the work path must be refused")
+	assert.Contains(t, *resp.Error, "path policy")
 }

--- a/internal/plugin/hostlibrary/pathpolicy_test.go
+++ b/internal/plugin/hostlibrary/pathpolicy_test.go
@@ -114,7 +114,7 @@ func linuxNode() *domain.Node {
 func TestPathScope_unrestricted_refuses_only_traversal(t *testing.T) {
 	t.Parallel()
 
-	scope, err := DefaultPathPolicy().ScopeFor(context.Background(), linuxNode())
+	scope, err := DefaultPathPolicy().ScopeFor(context.Background(), linuxNode(), testPluginID)
 	require.NoError(t, err)
 
 	assert.Nil(t, scope.Check("/etc/passwd"))
@@ -133,7 +133,7 @@ func TestPathScope_node_workpath(t *testing.T) {
 	policy, err := NewPathPolicy(PathPolicyConfig{Mode: PathPolicyNodeWorkPath, AllowedPaths: []string{"/opt/shared"}}, nil)
 	require.NoError(t, err)
 
-	scope, err := policy.ScopeFor(context.Background(), linuxNode())
+	scope, err := policy.ScopeFor(context.Background(), linuxNode(), testPluginID)
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -175,7 +175,7 @@ func TestPathScope_windows_nodes_compare_case_insensitively(t *testing.T) {
 	policy, err := NewPathPolicy(PathPolicyConfig{Mode: PathPolicyNodeWorkPath}, nil)
 	require.NoError(t, err)
 
-	scope, err := policy.ScopeFor(context.Background(), &domain.Node{ID: 2, OS: domain.NodeOSWindows, WorkPath: `C:\GameAP`})
+	scope, err := policy.ScopeFor(context.Background(), &domain.Node{ID: 2, OS: domain.NodeOSWindows, WorkPath: `C:\GameAP`}, testPluginID)
 	require.NoError(t, err)
 
 	assert.Nil(t, scope.Check(`c:\gameap\servers\cs`))
@@ -191,7 +191,7 @@ func TestPathScope_empty_work_path_fails_closed(t *testing.T) {
 	policy, err := NewPathPolicy(PathPolicyConfig{Mode: PathPolicyNodeWorkPath}, nil)
 	require.NoError(t, err)
 
-	_, err = policy.ScopeFor(context.Background(), &domain.Node{ID: 3, OS: domain.NodeOSLinux})
+	_, err = policy.ScopeFor(context.Background(), &domain.Node{ID: 3, OS: domain.NodeOSLinux}, testPluginID)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "work path is not configured")
 }
@@ -212,7 +212,7 @@ func TestPathScope_server_dirs(t *testing.T) {
 	policy, err := NewPathPolicy(PathPolicyConfig{Mode: PathPolicyServerDirs}, servers)
 	require.NoError(t, err)
 
-	scope, err := policy.ScopeFor(ctx, linuxNode())
+	scope, err := policy.ScopeFor(ctx, linuxNode(), testPluginID)
 	require.NoError(t, err)
 
 	assert.Nil(t, scope.Check("/home/servers/servers/cs/cfg/server.cfg"))
@@ -237,7 +237,7 @@ func TestPathScope_server_dirs_repository_failure_fails_closed(t *testing.T) {
 	policy, err := NewPathPolicy(PathPolicyConfig{Mode: PathPolicyServerDirs}, failingServerLister{})
 	require.NoError(t, err)
 
-	_, err = policy.ScopeFor(context.Background(), linuxNode())
+	_, err = policy.ScopeFor(context.Background(), linuxNode(), testPluginID)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to list the node's servers")
 }
@@ -247,14 +247,73 @@ func TestPathScope_nil_node_or_policy_is_unrestricted(t *testing.T) {
 
 	var nilPolicy *PathPolicy
 
-	scope, err := nilPolicy.ScopeFor(context.Background(), linuxNode())
+	scope, err := nilPolicy.ScopeFor(context.Background(), linuxNode(), testPluginID)
 	require.NoError(t, err)
 	assert.Nil(t, scope.Check("/anything"))
 
 	policy, err := NewPathPolicy(PathPolicyConfig{Mode: PathPolicyNodeWorkPath}, nil)
 	require.NoError(t, err)
 
-	scope, err = policy.ScopeFor(context.Background(), nil)
+	scope, err = policy.ScopeFor(context.Background(), nil, testPluginID)
 	require.NoError(t, err)
 	assert.Nil(t, scope.Check("/anything"))
+}
+
+func TestPluginServiceDir(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "/home/servers/.plugins/a4", PluginServiceDir("/home/servers", testPluginID))
+	assert.Equal(t, "/home/servers/.plugins/fi", PluginServiceDir("/home/servers/", 42),
+		"a trailing separator on the work path changes nothing")
+
+	// A transient load (the upload dry-run) owns no directory, and neither
+	// does a node with no work path configured: both answer empty so the
+	// caller adds no root rather than one rooted at "/".
+	assert.Empty(t, PluginServiceDir("/home/servers", 0))
+	assert.Empty(t, PluginServiceDir("", testPluginID))
+	assert.Empty(t, PluginServiceDir("   ", testPluginID))
+}
+
+// server_dirs is the strictest mode and names only the game servers' own
+// directories. Without the service directory a plugin could not stage so much
+// as a request file there, so every restricted mode keeps its own open.
+func TestPathScope_server_dirs_keeps_the_plugins_own_service_dir_open(t *testing.T) {
+	t.Parallel()
+
+	repo := inmemory.NewServerRepository()
+	require.NoError(t, repo.Save(context.Background(),
+		&domain.Server{Name: "cs2", DSID: 1, Dir: "servers/cs2"}))
+
+	policy, err := NewPathPolicy(PathPolicyConfig{Mode: PathPolicyServerDirs}, repo)
+	require.NoError(t, err)
+
+	scope, err := policy.ScopeFor(context.Background(), linuxNode(), testPluginID)
+	require.NoError(t, err)
+
+	assert.Nil(t, scope.Check("/home/servers/.plugins/a4"))
+	assert.Nil(t, scope.Check("/home/servers/.plugins/a4/req/req-1.json"))
+	assert.Nil(t, scope.Check("/home/servers/servers/cs2/cfg/server.cfg"),
+		"the server directories are still the point of the mode")
+
+	// One plugin's scratch space is not another's.
+	require.NotNil(t, scope.Check("/home/servers/.plugins/fi/req/req-1.json"))
+	// And the root above them is nobody's.
+	require.NotNil(t, scope.Check("/home/servers/.plugins"))
+	require.NotNil(t, scope.Check("/home/servers/backups"))
+}
+
+// A transient load has no id, so it gets no service directory — it must not
+// fall back to something broader.
+func TestPathScope_a_transient_load_gets_no_service_dir(t *testing.T) {
+	t.Parallel()
+
+	repo := inmemory.NewServerRepository()
+	policy, err := NewPathPolicy(PathPolicyConfig{Mode: PathPolicyServerDirs}, repo)
+	require.NoError(t, err)
+
+	scope, err := policy.ScopeFor(context.Background(), linuxNode(), 0)
+	require.NoError(t, err)
+
+	assert.NotNil(t, scope.Check("/home/servers/.plugins/a4/req/req-1.json"))
+	assert.NotNil(t, scope.Check("/home/servers"))
 }

--- a/internal/plugin/hostlibrary/policy.go
+++ b/internal/plugin/hostlibrary/policy.go
@@ -18,6 +18,7 @@ const (
 	ModuleCache          = "gameap-cache"
 	ModuleStorage        = "gameap-storage"
 	ModuleSSH            = "gameap-ssh"
+	ModuleNodes          = "gameap-nodes"
 	// ModuleHost is open to every plugin (introspection only).
 	ModuleHost = "gameap-host"
 )
@@ -57,8 +58,8 @@ type RPCPolicy struct {
 // rate limit each privileged host function is subject to. It drives the
 // guard (enforcement), the "used permissions" the panel derives from a
 // module's import section (dry-run and admin UI), and the documentation.
-// Read-only modules (users, nodes, games, gamemods, authz, servers.find/get,
-// ...) have no entry and need no grant.
+// Read-only modules (users, games, gamemods, authz, servers.find/get,
+// nodes.find_nodes/get_node, ...) have no entry and need no grant.
 var hostRPCPolicies = buildHostRPCPolicies()
 
 func buildHostRPCPolicies() map[HostRPC]RPCPolicy {
@@ -124,6 +125,15 @@ func buildHostRPCPolicies() map[HostRPC]RPCPolicy {
 		RPCPolicy{Permission: domain.PluginPermissionSSH, RateClass: RateClassSSH},
 		"generate_key_pair", "connect", "disconnect", "exec", "start_exec",
 		"get_exec_operation", "cancel_exec", "write_file", "read_file")
+
+	// gameap-nodes checks manage_nodes itself rather than through the guard,
+	// so these entries do not enforce anything — they are here because the
+	// table is also what the panel derives a module's used permissions from,
+	// and without them a plugin that renames or retires nodes reads as needing
+	// no grant at all in the upload dry-run and the admin UI.
+	add(ModuleNodes,
+		RPCPolicy{Permission: domain.PluginPermissionManageNodes},
+		"update_node", "delete_node", "create_setup_key", "get_setup_key", "revoke_setup_key")
 
 	return policies
 }

--- a/pkg/plugin/README.md
+++ b/pkg/plugin/README.md
@@ -546,15 +546,40 @@ for _, file := range readDirResp.Files {
     fmt.Printf("%s (%d bytes)\n", file.Name, file.Size)
 }
 
-// Download a file. Download and Upload carry the whole file in one message,
-// so the panel caps them (PLUGIN_NODEFS_MAX_INLINE, 32 MiB by default);
-// a larger file answers with an error naming both sizes — use archives or an
-// HTTPResponse file reference for big payloads.
+// Download a file. Without Offset/Length this is the whole file in one
+// message, so the panel caps it (PLUGIN_NODEFS_MAX_INLINE, 32 MiB by default)
+// and a larger file answers with an error naming both sizes.
 downloadResp, _ := fs.Download(ctx, &nodefs.DownloadRequest{
     NodeId: 1,
     Path:   "/home/servers/server.cfg",
 })
 content := downloadResp.Content
+
+// Naming a window reads a larger file a piece at a time: only the window has
+// to fit the cap. The answer echoes Offset and carries TotalSize, so paging
+// needs no separate GetFileInfo. Reading at or past the end is not an error —
+// it answers empty content, which is how the loop below ends.
+var whole []byte
+for offset := uint64(0); ; {
+    page, _ := fs.Download(ctx, &nodefs.DownloadRequest{
+        NodeId: 1,
+        Path:   "/home/servers/world.tar.gz",
+        Offset: offset,
+        Length: 8 << 20,
+    })
+    if page.Error != nil || len(page.Content) == 0 {
+        break
+    }
+    whole = append(whole, page.Content...)
+    offset += uint64(len(page.Content))
+    if offset >= page.TotalSize {
+        break
+    }
+}
+
+// To hand a whole large file to a *client* rather than read it here, answer
+// the route with an HTTPResponse file reference instead: the panel streams it
+// and the bytes never enter guest memory.
 
 // Upload a file
 fs.Upload(ctx, &nodefs.UploadRequest{
@@ -1109,8 +1134,11 @@ func (p MyPlugin) HandleHTTPRequest(ctx context.Context, req *proto.HTTPRequest)
 
 A route can hand the client a file that lives on a node without the bytes
 passing through the plugin: answer with `File` instead of `Body` and the
-panel streams it from the daemon itself (so the 1 MB response limit and the
-guest memory do not apply).
+panel streams it from the daemon itself, so neither the guest memory nor the
+guest call deadline bounds the size — the transfer runs after the call returns
+and does not hold the plugin's call gate. (The 1 MB cap is on the *request*
+body, `DefaultMaxBodySize`; a plugin's own response body is bounded only by
+guest memory.)
 
 ```go
 case "/my-plugin/backups/latest":
@@ -1127,9 +1155,12 @@ case "/my-plugin/backups/latest":
 
 Rules:
 
-- Requires the `files` grant (the same one that gates `gameap-nodefs`); without
-  it the panel answers `403` and records an `access.denied` audit event. The check
-  happens on every request, at the moment the file is served.
+- Requires the `files_read` grant, which `files` includes — the same grant that
+  gates reading through `gameap-nodefs`, so a plugin can only stream what it
+  could read itself. Without it the panel answers `403` and records an
+  `access.denied` audit event. The check happens on every request, at the moment
+  the file is served, and is subject to `PLUGIN_PERMISSIONS_ENFORCE` like every
+  other grant check.
 - Only authenticated clients receive files: on a route with `RequiresAuth:
   false` an anonymous request gets `401`, whatever the plugin answered.
 - `Body` is ignored when `File` is set. `StatusCode` (default `200`) is the
@@ -1139,9 +1170,18 @@ Rules:
   everything else (`Set-Cookie`, `Location`, `WWW-Authenticate`, CSP, other
   `X-*` names such as `X-Accel-Redirect`, …) is dropped, as the response is
   served from the panel origin. The panel owns `Content-Length` and
-  `Content-Disposition` (always an attachment).
-- Range requests are not supported (`Accept-Ranges: none`); `..` path segments
-  are rejected.
+  `Content-Disposition` (always an attachment). The declared length is the one
+  the stat reported and the copy is bounded by it, so a file that changed
+  between the stat and the read ends the response as an error rather than as a
+  body that quietly disagrees with its header.
+- Range requests are served (`Accept-Ranges: bytes`), so an interrupted download
+  resumes instead of starting over: a satisfiable `Range` answers `206` with
+  `Content-Range`, and one past the end answers `416`. A single range only —
+  a multi-range header is ignored and the whole file is sent, which is what a
+  resuming client wants anyway. A range is not applied when the plugin named its
+  own status code, since that answer is the plugin's to define.
+- `..` path segments are rejected, and the path is subject to the operator's
+  path policy.
 - Panels that predate this field ignore it and send an empty body, so a plugin
   that must run on older panels should keep a `Body` fallback for them.
 
@@ -1378,7 +1418,7 @@ Privileged host modules are gated on the plugin's own grants, kept in the
 | `manage_rbac` | `gameap-rbac` — creating roles, granting and revoking abilities |
 | `secrets` | `gameap-secrets` — reading, writing, listing and deleting the plugin's encrypted credentials |
 | `ssh` | every `gameap-ssh` operation — connecting to a host the plugin names itself, running commands on it and transferring files, all outside the daemon and the node inventory; key generation included, so a plugin cannot mint credentials without the grant. The grant alone is not enough: the operator must also set `PLUGIN_SSH_ENABLED=true` |
-| `manage_nodes` | `gameap-nodes` — the mutating calls: `UpdateNode`, `DeleteNode` and the enrollment setup keys. Reads stay open to every plugin |
+| `manage_nodes` | `gameap-nodes` — the mutating calls: `UpdateNode`, `DeleteNode` and the enrollment setup keys. Reads stay open to every plugin. The module checks this grant itself rather than through the guard, so it is enforced whatever `PLUGIN_PERMISSIONS_ENFORCE` says and carries no rate limit of its own |
 
 `manage_games`, `manage_game_mods` and `manage_users` are reserved for write
 operations the repository modules do not expose yet.
@@ -1465,8 +1505,24 @@ byte is refused. `PLUGIN_NODEFS_PATH_POLICY` selects what else is allowed:
 | `node_workpath` | inside the node's `work_path`; relative paths are resolved under it |
 | `server_dirs` | inside the directory of a game server on that node (`work_path/<server dir>`, soft-deleted servers excluded); `work_dir` of a command must be absolute |
 
+In both restricted modes the plugin's service directory (below) is allowed as well.
+
+Every restricted mode additionally keeps one directory open: the plugin's own
+**service directory**, `<work_path>/.plugins/<plugin id>` — the id being the
+compact form the plugin's routes use. That is where a plugin belongs when it
+needs scratch space on a node: staged request files, results a long node
+command writes back, an archive built for download. It is per plugin and per
+node, resolved from that node's own work path, so nothing has to be configured
+and one plugin cannot reach another's files. A plugin loaded transiently (the
+upload dry-run) has no id yet and gets no directory.
+
+Put node-side working files there and the strictest mode still works. Put them
+anywhere else under the work path and `server_dirs` refuses them.
+
 `PLUGIN_NODEFS_ALLOWED_PATHS` (comma-separated absolute roots) widens the
-restricted modes, e.g. a shared `/opt/steamcmd`. Windows nodes are compared
+restricted modes further, e.g. a shared `/opt/steamcmd`. It is a poor fit for
+plugin working directories: the roots are absolute and apply to every node, so
+a fleet with different work paths cannot be covered by one entry. Windows nodes are compared
 case-insensitively with `\` normalised to `/`; symbolic links are not
 resolved on the panel (the daemon still confines plugins to what it serves).
 A refused call answers `path policy: <reason>: <path>` in the response's
@@ -1627,8 +1683,10 @@ variable name.
   out-of-memory.
 - `PLUGIN_RUNTIME_MAX_MODULE_SIZE` (128M) rejects larger wasm files before
   compilation, for uploads, store installs and autoload alike.
-- `PLUGIN_NODEFS_MAX_INLINE` (32 MiB) caps `gameap-nodefs`
-  `Download`/`Upload` payloads.
+- `PLUGIN_NODEFS_MAX_INLINE` (32 MiB) caps `gameap-nodefs` `Upload` payloads and
+  what one `Download` may answer with. A `Download` that names an
+  `Offset`/`Length` window is measured by the window, so a larger file stays
+  readable one piece at a time.
 - Guest `stdout` is forwarded to the panel log at debug level and `stderr` at
   warn level (attributes `plugin_id`, `stream`, `line`), so a Go/Rust panic
   message is visible. Lines are cut at 4 KiB and each stream is limited to

--- a/pkg/plugin/README.md
+++ b/pkg/plugin/README.md
@@ -558,7 +558,9 @@ content := downloadResp.Content
 // Naming a window reads a larger file a piece at a time: only the window has
 // to fit the cap. The answer echoes Offset and carries TotalSize, so paging
 // needs no separate GetFileInfo. Reading at or past the end is not an error —
-// it answers empty content, which is how the loop below ends.
+// it answers empty content, which is how the loop below ends. A Length above
+// the cap is refused ("window too large: ..."), not quietly clamped; a full
+// window is the ordinary answer and never an error.
 var whole []byte
 for offset := uint64(0); ; {
     page, _ := fs.Download(ctx, &nodefs.DownloadRequest{
@@ -576,6 +578,11 @@ for offset := uint64(0); ; {
         break
     }
 }
+
+// Length: 0 with an Offset asks for "as much as the cap allows", so it is
+// len(Content) — not the Length asked for — that says how much was served.
+// Advancing by len(Content), as above, is therefore what a paging loop wants
+// either way.
 
 // To hand a whole large file to a *client* rather than read it here, answer
 // the route with an HTTPResponse file reference instead: the panel streams it

--- a/pkg/plugin/sdk/nodefs/nodefs.pb.go
+++ b/pkg/plugin/sdk/nodefs/nodefs.pb.go
@@ -592,6 +592,15 @@ type DownloadRequest struct {
 
 	NodeId uint64 `protobuf:"varint,1,opt,name=node_id,json=nodeId,proto3" json:"node_id,omitempty"`
 	Path   string `protobuf:"bytes,2,opt,name=path,proto3" json:"path,omitempty"`
+	// Byte offset to read from; 0 starts at the beginning. An offset at or past
+	// the end of the file is not an error: the answer is empty content with
+	// total_size set, which is how a caller paging through a file learns it is
+	// done.
+	Offset uint64 `protobuf:"varint,3,opt,name=offset,proto3" json:"offset,omitempty"`
+	// Bytes to read; 0 means "as much as the inline limit allows". It is the
+	// window, not the file, that has to fit the limit — a file larger than the
+	// limit is readable one window at a time rather than refused outright.
+	Length uint64 `protobuf:"varint,4,opt,name=length,proto3" json:"length,omitempty"`
 }
 
 func (x *DownloadRequest) ProtoReflect() protoreflect.Message {
@@ -612,6 +621,20 @@ func (x *DownloadRequest) GetPath() string {
 	return ""
 }
 
+func (x *DownloadRequest) GetOffset() uint64 {
+	if x != nil {
+		return x.Offset
+	}
+	return 0
+}
+
+func (x *DownloadRequest) GetLength() uint64 {
+	if x != nil {
+		return x.Length
+	}
+	return 0
+}
+
 type DownloadResponse struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -619,6 +642,14 @@ type DownloadResponse struct {
 
 	Content []byte  `protobuf:"bytes,1,opt,name=content,proto3" json:"content,omitempty"`
 	Error   *string `protobuf:"bytes,2,opt,name=error,proto3,oneof" json:"error,omitempty"`
+	// The offset the content starts at, echoed back.
+	Offset uint64 `protobuf:"varint,3,opt,name=offset,proto3" json:"offset,omitempty"`
+	// Size of the whole file, so a caller paging through one does not need a
+	// separate GetFileInfo. Set whenever the panel had to stat the file — that
+	// is, on every windowed read and on every panel with an inline limit
+	// configured (the default). Zero means it was not measured, which only an
+	// uncapped panel answering a whole-file read can produce.
+	TotalSize uint64 `protobuf:"varint,4,opt,name=total_size,json=totalSize,proto3" json:"total_size,omitempty"`
 }
 
 func (x *DownloadResponse) ProtoReflect() protoreflect.Message {
@@ -637,6 +668,20 @@ func (x *DownloadResponse) GetError() string {
 		return *x.Error
 	}
 	return ""
+}
+
+func (x *DownloadResponse) GetOffset() uint64 {
+	if x != nil {
+		return x.Offset
+	}
+	return 0
+}
+
+func (x *DownloadResponse) GetTotalSize() uint64 {
+	if x != nil {
+		return x.TotalSize
+	}
+	return 0
 }
 
 type UploadRequest struct {

--- a/pkg/plugin/sdk/nodefs/nodefs.proto
+++ b/pkg/plugin/sdk/nodefs/nodefs.proto
@@ -122,11 +122,28 @@ message MoveResponse {
 message DownloadRequest {
   uint64 node_id = 1;
   string path = 2;
+  // Byte offset to read from; 0 starts at the beginning. An offset at or past
+  // the end of the file is not an error: the answer is empty content with
+  // total_size set, which is how a caller paging through a file learns it is
+  // done.
+  uint64 offset = 3;
+  // Bytes to read; 0 means "as much as the inline limit allows". It is the
+  // window, not the file, that has to fit the limit — a file larger than the
+  // limit is readable one window at a time rather than refused outright.
+  uint64 length = 4;
 }
 
 message DownloadResponse {
   bytes content = 1;
   optional string error = 2;
+  // The offset the content starts at, echoed back.
+  uint64 offset = 3;
+  // Size of the whole file, so a caller paging through one does not need a
+  // separate GetFileInfo. Set whenever the panel had to stat the file — that
+  // is, on every windowed read and on every panel with an inline limit
+  // configured (the default). Zero means it was not measured, which only an
+  // uncapped panel answering a whole-file read can produce.
+  uint64 total_size = 4;
 }
 
 message UploadRequest {

--- a/pkg/plugin/sdk/nodefs/nodefs_vtproto.pb.go
+++ b/pkg/plugin/sdk/nodefs/nodefs_vtproto.pb.go
@@ -583,6 +583,16 @@ func (m *DownloadRequest) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if m.Length != 0 {
+		i = encodeVarint(dAtA, i, uint64(m.Length))
+		i--
+		dAtA[i] = 0x20
+	}
+	if m.Offset != 0 {
+		i = encodeVarint(dAtA, i, uint64(m.Offset))
+		i--
+		dAtA[i] = 0x18
+	}
 	if len(m.Path) > 0 {
 		i -= len(m.Path)
 		copy(dAtA[i:], m.Path)
@@ -627,6 +637,16 @@ func (m *DownloadResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.TotalSize != 0 {
+		i = encodeVarint(dAtA, i, uint64(m.TotalSize))
+		i--
+		dAtA[i] = 0x20
+	}
+	if m.Offset != 0 {
+		i = encodeVarint(dAtA, i, uint64(m.Offset))
+		i--
+		dAtA[i] = 0x18
 	}
 	if m.Error != nil {
 		i -= len(*m.Error)
@@ -2338,6 +2358,12 @@ func (m *DownloadRequest) SizeVT() (n int) {
 	if l > 0 {
 		n += 1 + l + sov(uint64(l))
 	}
+	if m.Offset != 0 {
+		n += 1 + sov(uint64(m.Offset))
+	}
+	if m.Length != 0 {
+		n += 1 + sov(uint64(m.Length))
+	}
 	n += len(m.unknownFields)
 	return n
 }
@@ -2355,6 +2381,12 @@ func (m *DownloadResponse) SizeVT() (n int) {
 	if m.Error != nil {
 		l = len(*m.Error)
 		n += 1 + l + sov(uint64(l))
+	}
+	if m.Offset != 0 {
+		n += 1 + sov(uint64(m.Offset))
+	}
+	if m.TotalSize != 0 {
+		n += 1 + sov(uint64(m.TotalSize))
 	}
 	n += len(m.unknownFields)
 	return n
@@ -4318,6 +4350,44 @@ func (m *DownloadRequest) UnmarshalVT(dAtA []byte) error {
 			}
 			m.Path = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
+		case 3:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Offset", wireType)
+			}
+			m.Offset = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Offset |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 4:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Length", wireType)
+			}
+			m.Length = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Length |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
 		default:
 			iNdEx = preIndex
 			skippy, err := skip(dAtA[iNdEx:])
@@ -4436,6 +4506,44 @@ func (m *DownloadResponse) UnmarshalVT(dAtA []byte) error {
 			s := string(dAtA[iNdEx:postIndex])
 			m.Error = &s
 			iNdEx = postIndex
+		case 3:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Offset", wireType)
+			}
+			m.Offset = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Offset |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 4:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field TotalSize", wireType)
+			}
+			m.TotalSize = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.TotalSize |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
 		default:
 			iNdEx = preIndex
 			skippy, err := skip(dAtA[iNdEx:])


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for resumable file downloads using single byte-range requests.
  * Large files can now stream efficiently, including bounded and open-ended download windows.
  * File responses report range support, content length, and appropriate range metadata.
  * Plugin file access now supports offset-based reads and clearer end-of-file handling.
  * Added plugin-specific working directories and improved path isolation.
  * Added node read and management permission coverage, including `manage_nodes` enforcement.
* **Documentation**
  * Documented ranged downloads, streaming behavior, permissions, limits, and plugin service directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->