### PR TITLE
attach server

### DIFF
--- a/internal/acme/service_test.go
+++ b/internal/acme/service_test.go
@@ -373,12 +373,15 @@ func TestService_RenewalLoop_TriggersRenewalWhenThresholdCrossed(t *testing.T) {
 	}, 2*time.Second, 20*time.Millisecond,
 		"renewal loop must invoke RenewCertificate when cert is past threshold")
 
-	cert, err := svc.GetCertificate(nil)
-	require.NoError(t, err)
-	require.NotNil(t, cert.Leaf)
-	assert.True(t, cert.Leaf.NotAfter.After(time.Now().Add(2*time.Hour)),
-		"served cert NotAfter must be far in the future after renewal, got %v",
-		cert.Leaf.NotAfter)
+	// The renewed certificate is installed after RenewCertificate returns
+	// (save → parse → apply), so the swap lags the call counter.
+	assert.Eventually(t, func() bool {
+		cert, err := svc.GetCertificate(nil)
+
+		return err == nil && cert.Leaf != nil &&
+			cert.Leaf.NotAfter.After(time.Now().Add(2*time.Hour))
+	}, 2*time.Second, 20*time.Millisecond,
+		"served cert NotAfter must be far in the future after renewal")
 }
 
 func TestService_RenewalLoop_SkipsRenewalWhenCertFresh(t *testing.T) {

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -139,6 +139,7 @@ import (
 	"github.com/gameap/gameap/internal/api/tokens/posttoken"
 	"github.com/gameap/gameap/internal/api/user/getuser"
 	"github.com/gameap/gameap/internal/api/users/deleteuser"
+	"github.com/gameap/gameap/internal/api/users/deleteuserserver"
 	"github.com/gameap/gameap/internal/api/users/getserverperms"
 	usersgetuser "github.com/gameap/gameap/internal/api/users/getuser"
 	"github.com/gameap/gameap/internal/api/users/getusers"
@@ -146,6 +147,7 @@ import (
 	"github.com/gameap/gameap/internal/api/users/postusers"
 	"github.com/gameap/gameap/internal/api/users/putserverperms"
 	"github.com/gameap/gameap/internal/api/users/putuser"
+	"github.com/gameap/gameap/internal/api/users/putuserserver"
 	"github.com/gameap/gameap/internal/api/version/getversion"
 	wsattach "github.com/gameap/gameap/internal/api/ws/attach"
 	wsconsole "github.com/gameap/gameap/internal/api/ws/console"
@@ -1505,6 +1507,38 @@ func apiRoutes(c container, router *mux.Router) *mux.Router {
 				c.RBAC(),
 				c.Responder(),
 				c.PluginManager(),
+			),
+			AdminOnly: true,
+			CheckPATAbilities: []domain.PATAbility{
+				domain.PATAbilityUserManage,
+			},
+		},
+		{
+			Method: http.MethodPut,
+			Path:   "/api/users/{id}/servers/{server}",
+			Handler: putuserserver.NewHandler(
+				c.UserRepository(),
+				c.ServerRepository(),
+				c.RBAC(),
+				c.Responder(),
+				c.AuditLogger(),
+				c.PluginDispatcher(),
+			),
+			AdminOnly: true,
+			CheckPATAbilities: []domain.PATAbility{
+				domain.PATAbilityUserManage,
+			},
+		},
+		{
+			Method: http.MethodDelete,
+			Path:   "/api/users/{id}/servers/{server}",
+			Handler: deleteuserserver.NewHandler(
+				c.UserRepository(),
+				c.ServerRepository(),
+				c.RBAC(),
+				c.Responder(),
+				c.AuditLogger(),
+				c.PluginDispatcher(),
 			),
 			AdminOnly: true,
 			CheckPATAbilities: []domain.PATAbility{

--- a/internal/api/router_security_escalation_test.go
+++ b/internal/api/router_security_escalation_test.go
@@ -48,6 +48,8 @@ var adminMutatingEndpoints = []adminEndpoint{
 	{http.MethodGet, "/api/users/2/servers", "", "list other user's servers"},
 	{http.MethodGet, "/api/users/2/servers/1/permissions", "", "read other user's server permissions"},
 	{http.MethodPut, "/api/users/2/servers/1/permissions", `{"abilities":[]}`, "grant server permissions"},
+	{http.MethodPut, "/api/users/2/servers/1", "", "attach server to user"},
+	{http.MethodDelete, "/api/users/2/servers/1", "", "detach server from user"},
 
 	// Games management
 	{http.MethodPost, "/api/games", `{"code":"x","name":"X","engine":"source"}`, "create game"},

--- a/internal/api/users/deleteuserserver/handler.go
+++ b/internal/api/users/deleteuserserver/handler.go
@@ -1,0 +1,146 @@
+package deleteuserserver
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"strconv"
+
+	"github.com/gameap/gameap/internal/api/base"
+	"github.com/gameap/gameap/internal/audit"
+	"github.com/gameap/gameap/internal/domain"
+	"github.com/gameap/gameap/internal/filters"
+	"github.com/gameap/gameap/internal/repositories"
+	"github.com/gameap/gameap/pkg/api"
+	"github.com/gameap/gameap/pkg/auth"
+	pluginproto "github.com/gameap/gameap/pkg/plugin/proto"
+	"github.com/pkg/errors"
+)
+
+// PluginDispatcher publishes user events to plugins; satisfied by
+// *plugin.Dispatcher.
+type PluginDispatcher interface {
+	DispatchUserEventAsync(
+		ctx context.Context,
+		eventType pluginproto.EventType,
+		user *domain.User,
+		extraData map[string]string,
+	)
+}
+
+type Handler struct {
+	usersRepo        repositories.UserRepository
+	serversRepo      repositories.ServerRepository
+	rbac             base.RBAC
+	responder        base.Responder
+	audit            audit.Logger
+	pluginDispatcher PluginDispatcher
+}
+
+func NewHandler(
+	usersRepo repositories.UserRepository,
+	serversRepo repositories.ServerRepository,
+	rbac base.RBAC,
+	responder base.Responder,
+	auditLogger audit.Logger,
+	pluginDispatcher PluginDispatcher,
+) *Handler {
+	if auditLogger == nil {
+		auditLogger = audit.NopLogger{}
+	}
+
+	return &Handler{
+		usersRepo:        usersRepo,
+		serversRepo:      serversRepo,
+		rbac:             rbac,
+		responder:        responder,
+		audit:            auditLogger,
+		pluginDispatcher: pluginDispatcher,
+	}
+}
+
+// ServeHTTP detaches a server from a user. The server itself is not
+// required to exist so stale assignments can be removed; detaching a
+// server that is not attached is a no-op success.
+func (h *Handler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	session := auth.SessionFromContext(ctx)
+	if !session.IsAuthenticated() {
+		h.responder.WriteError(ctx, rw, api.WrapHTTPError(
+			errors.New("user not authenticated"),
+			http.StatusUnauthorized,
+		))
+
+		return
+	}
+
+	input := api.NewInputReader(r)
+
+	userID, err := input.ReadUint("id")
+	if err != nil {
+		h.responder.WriteError(ctx, rw, api.WrapHTTPError(
+			errors.WithMessage(err, "invalid user id"),
+			http.StatusBadRequest,
+		))
+
+		return
+	}
+
+	serverID, err := input.ReadUint("server")
+	if err != nil {
+		h.responder.WriteError(ctx, rw, api.WrapHTTPError(
+			errors.WithMessage(err, "invalid server id"),
+			http.StatusBadRequest,
+		))
+
+		return
+	}
+
+	users, err := h.usersRepo.Find(ctx, &filters.FindUser{
+		IDs: []uint{userID},
+	}, nil, &filters.Pagination{
+		Limit: 1,
+	})
+	if err != nil {
+		h.responder.WriteError(ctx, rw, errors.WithMessage(err, "failed to find user"))
+
+		return
+	}
+
+	if len(users) == 0 {
+		h.responder.WriteError(ctx, rw, api.NewNotFoundError("user not found"))
+
+		return
+	}
+
+	user := &users[0]
+
+	if err := base.EnsureTargetNotAdminForToken(ctx, h.rbac, user.ID); err != nil {
+		if errors.Is(err, base.ErrTokenCannotModifyAdmin) {
+			audit.AccessDenied(ctx, h.audit, "user",
+				strconv.FormatUint(uint64(user.ID), 10), "token_target_is_admin")
+		}
+		h.responder.WriteError(ctx, rw, err)
+
+		return
+	}
+
+	err = h.serversRepo.DetachUserServer(ctx, userID, serverID)
+	if err != nil {
+		h.responder.WriteError(ctx, rw, errors.WithMessage(err, "failed to detach server from user"))
+
+		return
+	}
+
+	audit.SensitiveOp(ctx, h.audit, audit.EventUserServerDetach, audit.CategoryAdminOp,
+		"user", strconv.FormatUint(uint64(user.ID), 10), "server_detach",
+		slog.Uint64("server_id", uint64(serverID)))
+
+	if h.pluginDispatcher != nil {
+		h.pluginDispatcher.DispatchUserEventAsync(ctx, pluginproto.EventType_EVENT_TYPE_USER_UPDATED, user,
+			map[string]string{"changed_fields": "servers"})
+	}
+
+	rw.WriteHeader(http.StatusNoContent)
+}

--- a/internal/api/users/deleteuserserver/handler_test.go
+++ b/internal/api/users/deleteuserserver/handler_test.go
@@ -1,0 +1,316 @@
+package deleteuserserver
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/gameap/gameap/internal/audit"
+	"github.com/gameap/gameap/internal/domain"
+	"github.com/gameap/gameap/internal/rbac"
+	"github.com/gameap/gameap/internal/repositories/inmemory"
+	"github.com/gameap/gameap/internal/services"
+	"github.com/gameap/gameap/pkg/api"
+	"github.com/gameap/gameap/pkg/auth"
+	"github.com/google/uuid"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type auditCapture struct {
+	mu     sync.Mutex
+	events []audit.Event
+}
+
+func (a *auditCapture) Record(_ context.Context, e audit.Event) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.events = append(a.events, e)
+}
+
+func (a *auditCapture) snapshot() []audit.Event {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	return append([]audit.Event(nil), a.events...)
+}
+
+func findEvent(events []audit.Event, t audit.EventType) (audit.Event, bool) {
+	for _, e := range events {
+		if e.Type == t {
+			return e, true
+		}
+	}
+
+	return audit.Event{}, false
+}
+
+var testAdmin = domain.User{
+	ID:    1,
+	Login: "admin",
+	Email: "admin@example.com",
+}
+
+func saveTestServer(t *testing.T, serversRepo *inmemory.ServerRepository) {
+	t.Helper()
+
+	server := &domain.Server{
+		ID:         1,
+		UID:        uuid.New(),
+		UUIDShort:  "detach01",
+		Name:       "Test Server",
+		GameID:     "csgo",
+		DSID:       1,
+		ServerIP:   "192.168.1.1",
+		ServerPort: 27015,
+		Dir:        "/servers/detach01",
+	}
+	require.NoError(t, serversRepo.Save(context.Background(), server))
+}
+
+func authenticatedCtx() context.Context {
+	session := &auth.Session{
+		Login: "admin",
+		Email: "admin@example.com",
+		User:  &testAdmin,
+	}
+
+	return auth.ContextWithSession(context.Background(), session)
+}
+
+func TestHandler_ServeHTTP(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		userID          string
+		serverID        string
+		setupAuth       func() context.Context
+		setupRepo       func(*testing.T, *inmemory.UserRepository, *inmemory.ServerRepository, *inmemory.RBACRepository)
+		expectedStatus  int
+		wantError       string
+		verifyUserID    uint
+		wantAttachedIDs []uint
+		wantAuditEvent  bool
+	}{
+		{
+			name:      "successful_detach",
+			userID:    "2",
+			serverID:  "1",
+			setupAuth: authenticatedCtx,
+			setupRepo: func(t *testing.T, usersRepo *inmemory.UserRepository, serversRepo *inmemory.ServerRepository, _ *inmemory.RBACRepository) {
+				t.Helper()
+				require.NoError(t, usersRepo.Save(context.Background(), &domain.User{
+					ID: 2, Login: "target", Email: "target@example.com",
+				}))
+				saveTestServer(t, serversRepo)
+				serversRepo.AddUserServer(2, 1)
+			},
+			expectedStatus:  http.StatusNoContent,
+			verifyUserID:    2,
+			wantAttachedIDs: []uint{},
+			wantAuditEvent:  true,
+		},
+		{
+			name:      "detach_keeps_other_servers",
+			userID:    "2",
+			serverID:  "1",
+			setupAuth: authenticatedCtx,
+			setupRepo: func(t *testing.T, usersRepo *inmemory.UserRepository, serversRepo *inmemory.ServerRepository, _ *inmemory.RBACRepository) {
+				t.Helper()
+				require.NoError(t, usersRepo.Save(context.Background(), &domain.User{
+					ID: 2, Login: "target", Email: "target@example.com",
+				}))
+				saveTestServer(t, serversRepo)
+				require.NoError(t, serversRepo.Save(context.Background(), &domain.Server{
+					ID:         5,
+					UID:        uuid.New(),
+					UUIDShort:  "detach05",
+					Name:       "Kept Server",
+					GameID:     "csgo",
+					DSID:       1,
+					ServerIP:   "192.168.1.5",
+					ServerPort: 27016,
+					Dir:        "/servers/detach05",
+				}))
+				serversRepo.AddUserServer(2, 1)
+				serversRepo.AddUserServer(2, 5)
+			},
+			expectedStatus:  http.StatusNoContent,
+			verifyUserID:    2,
+			wantAttachedIDs: []uint{5},
+			wantAuditEvent:  true,
+		},
+		{
+			name:      "detach_not_attached_is_noop",
+			userID:    "2",
+			serverID:  "1",
+			setupAuth: authenticatedCtx,
+			setupRepo: func(t *testing.T, usersRepo *inmemory.UserRepository, serversRepo *inmemory.ServerRepository, _ *inmemory.RBACRepository) {
+				t.Helper()
+				require.NoError(t, usersRepo.Save(context.Background(), &domain.User{
+					ID: 2, Login: "target", Email: "target@example.com",
+				}))
+				saveTestServer(t, serversRepo)
+			},
+			expectedStatus:  http.StatusNoContent,
+			verifyUserID:    2,
+			wantAttachedIDs: []uint{},
+			wantAuditEvent:  true,
+		},
+		{
+			name:      "detach_missing_server_removes_stale_assignment",
+			userID:    "2",
+			serverID:  "77",
+			setupAuth: authenticatedCtx,
+			setupRepo: func(t *testing.T, usersRepo *inmemory.UserRepository, serversRepo *inmemory.ServerRepository, _ *inmemory.RBACRepository) {
+				t.Helper()
+				require.NoError(t, usersRepo.Save(context.Background(), &domain.User{
+					ID: 2, Login: "target", Email: "target@example.com",
+				}))
+				serversRepo.AddUserServer(2, 77)
+			},
+			expectedStatus:  http.StatusNoContent,
+			verifyUserID:    2,
+			wantAttachedIDs: []uint{},
+			wantAuditEvent:  true,
+		},
+		{
+			name:           "user_not_found",
+			userID:         "99",
+			serverID:       "1",
+			setupAuth:      authenticatedCtx,
+			expectedStatus: http.StatusNotFound,
+			wantError:      "user not found",
+		},
+		{
+			name:           "invalid_user_id",
+			userID:         "abc",
+			serverID:       "1",
+			setupAuth:      authenticatedCtx,
+			expectedStatus: http.StatusBadRequest,
+			wantError:      "invalid user id",
+		},
+		{
+			name:           "invalid_server_id",
+			userID:         "2",
+			serverID:       "abc",
+			setupAuth:      authenticatedCtx,
+			expectedStatus: http.StatusBadRequest,
+			wantError:      "invalid server id",
+		},
+		{
+			name:           "user_not_authenticated",
+			userID:         "2",
+			serverID:       "1",
+			setupAuth:      context.Background,
+			expectedStatus: http.StatusUnauthorized,
+			wantError:      "user not authenticated",
+		},
+		{
+			// OWASP API Top 10:2023 API5 (BFLA): a personal access token must
+			// not modify administrators, matching PUT /api/users/{id}.
+			name:     "pat_token_cannot_detach_from_admin",
+			userID:   "2",
+			serverID: "1",
+			setupAuth: func() context.Context {
+				session := &auth.Session{
+					Login: "operator",
+					Email: "operator@example.com",
+					User:  &domain.User{ID: 3, Login: "operator", Email: "operator@example.com"},
+					Token: &domain.PersonalAccessToken{ID: 1},
+				}
+
+				return auth.ContextWithSession(context.Background(), session)
+			},
+			setupRepo: func(t *testing.T, usersRepo *inmemory.UserRepository, serversRepo *inmemory.ServerRepository, rbacRepo *inmemory.RBACRepository) {
+				t.Helper()
+				require.NoError(t, usersRepo.Save(context.Background(), &domain.User{
+					ID: 2, Login: "rootadmin", Email: "rootadmin@example.com",
+				}))
+				saveTestServer(t, serversRepo)
+				serversRepo.AddUserServer(2, 1)
+
+				adminAbility := &domain.Ability{
+					Name: domain.AbilityNameAdminRolesPermissions,
+				}
+				require.NoError(t, rbacRepo.SaveAbility(context.Background(), adminAbility))
+
+				entityTypeUser := domain.EntityTypeUser
+				permission := &domain.Permission{
+					AbilityID:  adminAbility.ID,
+					EntityID:   new(uint(2)),
+					EntityType: &entityTypeUser,
+					Forbidden:  false,
+				}
+				require.NoError(t, rbacRepo.SavePermission(context.Background(), permission))
+			},
+			expectedStatus:  http.StatusForbidden,
+			wantError:       "personal access tokens cannot modify administrators",
+			verifyUserID:    2,
+			wantAttachedIDs: []uint{1},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			usersRepo := inmemory.NewUserRepository()
+			serversRepo := inmemory.NewServerRepository()
+			rbacRepo := inmemory.NewRBACRepository()
+			auditLog := &auditCapture{}
+			handler := NewHandler(
+				usersRepo,
+				serversRepo,
+				rbac.NewRBAC(services.NewNilTransactionManager(), rbacRepo, 0),
+				api.NewResponder(),
+				auditLog,
+				nil,
+			)
+
+			if tt.setupRepo != nil {
+				tt.setupRepo(t, usersRepo, serversRepo, rbacRepo)
+			}
+
+			req := httptest.NewRequest(http.MethodDelete, "/api/users/"+tt.userID+"/servers/"+tt.serverID, nil)
+			req = req.WithContext(tt.setupAuth())
+			req = mux.SetURLVars(req, map[string]string{"id": tt.userID, "server": tt.serverID})
+			w := httptest.NewRecorder()
+
+			handler.ServeHTTP(w, req)
+
+			assert.Equal(t, tt.expectedStatus, w.Code)
+
+			if tt.wantError != "" {
+				var response map[string]any
+				require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+				assert.Equal(t, "error", response["status"])
+				errorMsg, ok := response["error"].(string)
+				require.True(t, ok)
+				assert.Contains(t, errorMsg, tt.wantError)
+			}
+
+			if tt.verifyUserID != 0 {
+				servers, err := serversRepo.FindUserServers(context.Background(), tt.verifyUserID, nil, nil, nil)
+				require.NoError(t, err)
+				require.Len(t, servers, len(tt.wantAttachedIDs))
+				for i, wantID := range tt.wantAttachedIDs {
+					assert.Equal(t, wantID, servers[i].ID)
+				}
+			}
+
+			event, found := findEvent(auditLog.snapshot(), audit.EventUserServerDetach)
+			if tt.wantAuditEvent {
+				require.True(t, found, "expected user.server.detach audit event")
+				assert.Equal(t, tt.userID, event.ResourceID)
+			} else {
+				assert.False(t, found, "no user.server.detach audit event expected")
+			}
+		})
+	}
+}

--- a/internal/api/users/putuserserver/handler.go
+++ b/internal/api/users/putuserserver/handler.go
@@ -1,0 +1,155 @@
+package putuserserver
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"strconv"
+
+	"github.com/gameap/gameap/internal/api/base"
+	"github.com/gameap/gameap/internal/audit"
+	"github.com/gameap/gameap/internal/domain"
+	"github.com/gameap/gameap/internal/filters"
+	"github.com/gameap/gameap/internal/repositories"
+	"github.com/gameap/gameap/pkg/api"
+	"github.com/gameap/gameap/pkg/auth"
+	pluginproto "github.com/gameap/gameap/pkg/plugin/proto"
+	"github.com/pkg/errors"
+)
+
+// PluginDispatcher publishes user events to plugins; satisfied by
+// *plugin.Dispatcher.
+type PluginDispatcher interface {
+	DispatchUserEventAsync(
+		ctx context.Context,
+		eventType pluginproto.EventType,
+		user *domain.User,
+		extraData map[string]string,
+	)
+}
+
+type Handler struct {
+	usersRepo        repositories.UserRepository
+	serversRepo      repositories.ServerRepository
+	rbac             base.RBAC
+	responder        base.Responder
+	audit            audit.Logger
+	pluginDispatcher PluginDispatcher
+}
+
+func NewHandler(
+	usersRepo repositories.UserRepository,
+	serversRepo repositories.ServerRepository,
+	rbac base.RBAC,
+	responder base.Responder,
+	auditLogger audit.Logger,
+	pluginDispatcher PluginDispatcher,
+) *Handler {
+	if auditLogger == nil {
+		auditLogger = audit.NopLogger{}
+	}
+
+	return &Handler{
+		usersRepo:        usersRepo,
+		serversRepo:      serversRepo,
+		rbac:             rbac,
+		responder:        responder,
+		audit:            auditLogger,
+		pluginDispatcher: pluginDispatcher,
+	}
+}
+
+func (h *Handler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	session := auth.SessionFromContext(ctx)
+	if !session.IsAuthenticated() {
+		h.responder.WriteError(ctx, rw, api.WrapHTTPError(
+			errors.New("user not authenticated"),
+			http.StatusUnauthorized,
+		))
+
+		return
+	}
+
+	input := api.NewInputReader(r)
+
+	userID, err := input.ReadUint("id")
+	if err != nil {
+		h.responder.WriteError(ctx, rw, api.WrapHTTPError(
+			errors.WithMessage(err, "invalid user id"),
+			http.StatusBadRequest,
+		))
+
+		return
+	}
+
+	serverID, err := input.ReadUint("server")
+	if err != nil {
+		h.responder.WriteError(ctx, rw, api.WrapHTTPError(
+			errors.WithMessage(err, "invalid server id"),
+			http.StatusBadRequest,
+		))
+
+		return
+	}
+
+	users, err := h.usersRepo.Find(ctx, &filters.FindUser{
+		IDs: []uint{userID},
+	}, nil, &filters.Pagination{
+		Limit: 1,
+	})
+	if err != nil {
+		h.responder.WriteError(ctx, rw, errors.WithMessage(err, "failed to find user"))
+
+		return
+	}
+
+	if len(users) == 0 {
+		h.responder.WriteError(ctx, rw, api.NewNotFoundError("user not found"))
+
+		return
+	}
+
+	user := &users[0]
+
+	if err := base.EnsureTargetNotAdminForToken(ctx, h.rbac, user.ID); err != nil {
+		if errors.Is(err, base.ErrTokenCannotModifyAdmin) {
+			audit.AccessDenied(ctx, h.audit, "user",
+				strconv.FormatUint(uint64(user.ID), 10), "token_target_is_admin")
+		}
+		h.responder.WriteError(ctx, rw, err)
+
+		return
+	}
+
+	serverExists, err := h.serversRepo.Exists(ctx, &filters.FindServer{IDs: []uint{serverID}})
+	if err != nil {
+		h.responder.WriteError(ctx, rw, errors.WithMessage(err, "failed to check server existence"))
+
+		return
+	}
+	if !serverExists {
+		h.responder.WriteError(ctx, rw, api.NewNotFoundError("server not found"))
+
+		return
+	}
+
+	err = h.serversRepo.AttachUserServer(ctx, userID, serverID)
+	if err != nil {
+		h.responder.WriteError(ctx, rw, errors.WithMessage(err, "failed to attach server to user"))
+
+		return
+	}
+
+	audit.SensitiveOp(ctx, h.audit, audit.EventUserServerAttach, audit.CategoryAdminOp,
+		"user", strconv.FormatUint(uint64(user.ID), 10), "server_attach",
+		slog.Uint64("server_id", uint64(serverID)))
+
+	if h.pluginDispatcher != nil {
+		h.pluginDispatcher.DispatchUserEventAsync(ctx, pluginproto.EventType_EVENT_TYPE_USER_UPDATED, user,
+			map[string]string{"changed_fields": "servers"})
+	}
+
+	rw.WriteHeader(http.StatusNoContent)
+}

--- a/internal/api/users/putuserserver/handler_test.go
+++ b/internal/api/users/putuserserver/handler_test.go
@@ -1,0 +1,285 @@
+package putuserserver
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/gameap/gameap/internal/audit"
+	"github.com/gameap/gameap/internal/domain"
+	"github.com/gameap/gameap/internal/rbac"
+	"github.com/gameap/gameap/internal/repositories/inmemory"
+	"github.com/gameap/gameap/internal/services"
+	"github.com/gameap/gameap/pkg/api"
+	"github.com/gameap/gameap/pkg/auth"
+	"github.com/google/uuid"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type auditCapture struct {
+	mu     sync.Mutex
+	events []audit.Event
+}
+
+func (a *auditCapture) Record(_ context.Context, e audit.Event) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.events = append(a.events, e)
+}
+
+func (a *auditCapture) snapshot() []audit.Event {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	return append([]audit.Event(nil), a.events...)
+}
+
+func findEvent(events []audit.Event, t audit.EventType) (audit.Event, bool) {
+	for _, e := range events {
+		if e.Type == t {
+			return e, true
+		}
+	}
+
+	return audit.Event{}, false
+}
+
+var testAdmin = domain.User{
+	ID:    1,
+	Login: "admin",
+	Email: "admin@example.com",
+}
+
+func saveTestServer(t *testing.T, serversRepo *inmemory.ServerRepository) {
+	t.Helper()
+
+	server := &domain.Server{
+		ID:         1,
+		UID:        uuid.New(),
+		UUIDShort:  "attach01",
+		Name:       "Test Server",
+		GameID:     "csgo",
+		DSID:       1,
+		ServerIP:   "192.168.1.1",
+		ServerPort: 27015,
+		Dir:        "/servers/attach01",
+	}
+	require.NoError(t, serversRepo.Save(context.Background(), server))
+}
+
+func authenticatedCtx() context.Context {
+	session := &auth.Session{
+		Login: "admin",
+		Email: "admin@example.com",
+		User:  &testAdmin,
+	}
+
+	return auth.ContextWithSession(context.Background(), session)
+}
+
+func TestHandler_ServeHTTP(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		userID          string
+		serverID        string
+		setupAuth       func() context.Context
+		setupRepo       func(*testing.T, *inmemory.UserRepository, *inmemory.ServerRepository, *inmemory.RBACRepository)
+		expectedStatus  int
+		wantError       string
+		verifyUserID    uint
+		wantAttachedIDs []uint
+		wantAuditEvent  bool
+	}{
+		{
+			name:      "successful_attach",
+			userID:    "2",
+			serverID:  "1",
+			setupAuth: authenticatedCtx,
+			setupRepo: func(t *testing.T, usersRepo *inmemory.UserRepository, serversRepo *inmemory.ServerRepository, _ *inmemory.RBACRepository) {
+				t.Helper()
+				require.NoError(t, usersRepo.Save(context.Background(), &domain.User{
+					ID: 2, Login: "target", Email: "target@example.com",
+				}))
+				saveTestServer(t, serversRepo)
+			},
+			expectedStatus:  http.StatusNoContent,
+			verifyUserID:    2,
+			wantAttachedIDs: []uint{1},
+			wantAuditEvent:  true,
+		},
+		{
+			name:      "attach_already_attached_is_idempotent",
+			userID:    "2",
+			serverID:  "1",
+			setupAuth: authenticatedCtx,
+			setupRepo: func(t *testing.T, usersRepo *inmemory.UserRepository, serversRepo *inmemory.ServerRepository, _ *inmemory.RBACRepository) {
+				t.Helper()
+				require.NoError(t, usersRepo.Save(context.Background(), &domain.User{
+					ID: 2, Login: "target", Email: "target@example.com",
+				}))
+				saveTestServer(t, serversRepo)
+				serversRepo.AddUserServer(2, 1)
+			},
+			expectedStatus:  http.StatusNoContent,
+			verifyUserID:    2,
+			wantAttachedIDs: []uint{1},
+			wantAuditEvent:  true,
+		},
+		{
+			name:      "user_not_found",
+			userID:    "99",
+			serverID:  "1",
+			setupAuth: authenticatedCtx,
+			setupRepo: func(t *testing.T, _ *inmemory.UserRepository, serversRepo *inmemory.ServerRepository, _ *inmemory.RBACRepository) {
+				t.Helper()
+				saveTestServer(t, serversRepo)
+			},
+			expectedStatus: http.StatusNotFound,
+			wantError:      "user not found",
+		},
+		{
+			name:      "server_not_found",
+			userID:    "2",
+			serverID:  "99",
+			setupAuth: authenticatedCtx,
+			setupRepo: func(t *testing.T, usersRepo *inmemory.UserRepository, _ *inmemory.ServerRepository, _ *inmemory.RBACRepository) {
+				t.Helper()
+				require.NoError(t, usersRepo.Save(context.Background(), &domain.User{
+					ID: 2, Login: "target", Email: "target@example.com",
+				}))
+			},
+			expectedStatus: http.StatusNotFound,
+			wantError:      "server not found",
+		},
+		{
+			name:           "invalid_user_id",
+			userID:         "abc",
+			serverID:       "1",
+			setupAuth:      authenticatedCtx,
+			expectedStatus: http.StatusBadRequest,
+			wantError:      "invalid user id",
+		},
+		{
+			name:           "invalid_server_id",
+			userID:         "2",
+			serverID:       "abc",
+			setupAuth:      authenticatedCtx,
+			expectedStatus: http.StatusBadRequest,
+			wantError:      "invalid server id",
+		},
+		{
+			name:           "user_not_authenticated",
+			userID:         "2",
+			serverID:       "1",
+			setupAuth:      context.Background,
+			expectedStatus: http.StatusUnauthorized,
+			wantError:      "user not authenticated",
+		},
+		{
+			// OWASP API Top 10:2023 API5 (BFLA): a personal access token must
+			// not modify administrators, matching PUT /api/users/{id}.
+			name:     "pat_token_cannot_attach_to_admin",
+			userID:   "2",
+			serverID: "1",
+			setupAuth: func() context.Context {
+				session := &auth.Session{
+					Login: "operator",
+					Email: "operator@example.com",
+					User:  &domain.User{ID: 3, Login: "operator", Email: "operator@example.com"},
+					Token: &domain.PersonalAccessToken{ID: 1},
+				}
+
+				return auth.ContextWithSession(context.Background(), session)
+			},
+			setupRepo: func(t *testing.T, usersRepo *inmemory.UserRepository, serversRepo *inmemory.ServerRepository, rbacRepo *inmemory.RBACRepository) {
+				t.Helper()
+				require.NoError(t, usersRepo.Save(context.Background(), &domain.User{
+					ID: 2, Login: "rootadmin", Email: "rootadmin@example.com",
+				}))
+				saveTestServer(t, serversRepo)
+
+				adminAbility := &domain.Ability{
+					Name: domain.AbilityNameAdminRolesPermissions,
+				}
+				require.NoError(t, rbacRepo.SaveAbility(context.Background(), adminAbility))
+
+				entityTypeUser := domain.EntityTypeUser
+				permission := &domain.Permission{
+					AbilityID:  adminAbility.ID,
+					EntityID:   new(uint(2)),
+					EntityType: &entityTypeUser,
+					Forbidden:  false,
+				}
+				require.NoError(t, rbacRepo.SavePermission(context.Background(), permission))
+			},
+			expectedStatus: http.StatusForbidden,
+			wantError:      "personal access tokens cannot modify administrators",
+			verifyUserID:   2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			usersRepo := inmemory.NewUserRepository()
+			serversRepo := inmemory.NewServerRepository()
+			rbacRepo := inmemory.NewRBACRepository()
+			auditLog := &auditCapture{}
+			handler := NewHandler(
+				usersRepo,
+				serversRepo,
+				rbac.NewRBAC(services.NewNilTransactionManager(), rbacRepo, 0),
+				api.NewResponder(),
+				auditLog,
+				nil,
+			)
+
+			if tt.setupRepo != nil {
+				tt.setupRepo(t, usersRepo, serversRepo, rbacRepo)
+			}
+
+			req := httptest.NewRequest(http.MethodPut, "/api/users/"+tt.userID+"/servers/"+tt.serverID, nil)
+			req = req.WithContext(tt.setupAuth())
+			req = mux.SetURLVars(req, map[string]string{"id": tt.userID, "server": tt.serverID})
+			w := httptest.NewRecorder()
+
+			handler.ServeHTTP(w, req)
+
+			assert.Equal(t, tt.expectedStatus, w.Code)
+
+			if tt.wantError != "" {
+				var response map[string]any
+				require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+				assert.Equal(t, "error", response["status"])
+				errorMsg, ok := response["error"].(string)
+				require.True(t, ok)
+				assert.Contains(t, errorMsg, tt.wantError)
+			}
+
+			if tt.verifyUserID != 0 {
+				servers, err := serversRepo.FindUserServers(context.Background(), tt.verifyUserID, nil, nil, nil)
+				require.NoError(t, err)
+				require.Len(t, servers, len(tt.wantAttachedIDs))
+				for i, wantID := range tt.wantAttachedIDs {
+					assert.Equal(t, wantID, servers[i].ID)
+				}
+			}
+
+			event, found := findEvent(auditLog.snapshot(), audit.EventUserServerAttach)
+			if tt.wantAuditEvent {
+				require.True(t, found, "expected user.server.attach audit event")
+				assert.Equal(t, tt.userID, event.ResourceID)
+			} else {
+				assert.False(t, found, "no user.server.attach audit event expected")
+			}
+		})
+	}
+}

--- a/internal/api/ws/servermetrics/handler_test.go
+++ b/internal/api/ws/servermetrics/handler_test.go
@@ -461,6 +461,8 @@ func (f *fakeServerRepo) SaveBulk(_ context.Context, _ []*domain.Server) error  
 func (f *fakeServerRepo) Delete(_ context.Context, _ uint) error                   { return nil }
 func (f *fakeServerRepo) SoftDelete(_ context.Context, _ uint) error               { return nil }
 func (f *fakeServerRepo) SetUserServers(_ context.Context, _ uint, _ []uint) error { return nil }
+func (f *fakeServerRepo) AttachUserServer(_ context.Context, _ uint, _ uint) error { return nil }
+func (f *fakeServerRepo) DetachUserServer(_ context.Context, _ uint, _ uint) error { return nil }
 func (f *fakeServerRepo) Exists(_ context.Context, _ *filters.FindServer) (bool, error) {
 	return len(f.servers) > 0, f.err
 }

--- a/internal/api/ws/taskstatus/handler_test.go
+++ b/internal/api/ws/taskstatus/handler_test.go
@@ -709,6 +709,8 @@ func (f *fakeServerRepo) SaveBulk(_ context.Context, _ []*domain.Server) error  
 func (f *fakeServerRepo) Delete(_ context.Context, _ uint) error                   { return nil }
 func (f *fakeServerRepo) SoftDelete(_ context.Context, _ uint) error               { return nil }
 func (f *fakeServerRepo) SetUserServers(_ context.Context, _ uint, _ []uint) error { return nil }
+func (f *fakeServerRepo) AttachUserServer(_ context.Context, _ uint, _ uint) error { return nil }
+func (f *fakeServerRepo) DetachUserServer(_ context.Context, _ uint, _ uint) error { return nil }
 
 func (f *fakeServerRepo) UpdateServerStatuses(
 	_ context.Context, _ uint, _ []repositories.ServerStatusUpdate,

--- a/internal/audit/event.go
+++ b/internal/audit/event.go
@@ -65,6 +65,8 @@ const (
 
 	EventUserUpdate           EventType = "user.update"
 	EventUserRolesAssign      EventType = "user.roles.assign"
+	EventUserServerAttach     EventType = "user.server.attach"
+	EventUserServerDetach     EventType = "user.server.detach"
 	EventPATCreate            EventType = "token.pat.create"
 	EventPATRevoke            EventType = "token.pat.revoke"
 	EventDaemonTokenIssue     EventType = "token.daemon.issue"

--- a/internal/i18n/de.json
+++ b/internal/i18n/de.json
@@ -992,6 +992,10 @@
     "update_success_msg": "Benutzer erfolgreich aktualisiert",
     "delete_success_msg": "Benutzer erfolgreich gelöscht",
     "privileges_saved_success_msg": "Berechtigungen erfolgreich gespeichert",
+    "server_attached_msg": "Server zugewiesen",
+    "server_detached_msg": "Server entfernt",
+    "confirm_server_detach": "Server vom Benutzer trennen?",
+    "servers_apply_hint": "Änderungen an der Serverzuweisung werden sofort übernommen, Speichern ist nicht erforderlich",
     "delete_self_error_msg": "Sie können sich nicht selbst löschen"
   },
   "validation": {

--- a/internal/i18n/de.json
+++ b/internal/i18n/de.json
@@ -995,7 +995,6 @@
     "server_attached_msg": "Server zugewiesen",
     "server_detached_msg": "Server entfernt",
     "confirm_server_detach": "Server vom Benutzer trennen?",
-    "servers_apply_hint": "Änderungen an der Serverzuweisung werden sofort übernommen, Speichern ist nicht erforderlich",
     "delete_self_error_msg": "Sie können sich nicht selbst löschen"
   },
   "validation": {

--- a/internal/i18n/en.json
+++ b/internal/i18n/en.json
@@ -997,7 +997,6 @@
     "server_attached_msg": "Server attached",
     "server_detached_msg": "Server detached",
     "confirm_server_detach": "Detach the server from the user?",
-    "servers_apply_hint": "Changes to server assignments are applied immediately, no Save needed",
     "delete_self_error_msg": "You can not delete yourself"
   },
   "validation": {

--- a/internal/i18n/en.json
+++ b/internal/i18n/en.json
@@ -994,6 +994,10 @@
     "update_success_msg": "User updated successfully",
     "delete_success_msg": "User deleted successfully",
     "privileges_saved_success_msg": "Privileges saved successfully",
+    "server_attached_msg": "Server attached",
+    "server_detached_msg": "Server detached",
+    "confirm_server_detach": "Detach the server from the user?",
+    "servers_apply_hint": "Changes to server assignments are applied immediately, no Save needed",
     "delete_self_error_msg": "You can not delete yourself"
   },
   "validation": {

--- a/internal/i18n/es.json
+++ b/internal/i18n/es.json
@@ -995,7 +995,6 @@
     "server_attached_msg": "Servidor asignado",
     "server_detached_msg": "Servidor desasignado",
     "confirm_server_detach": "¿Desasignar el servidor del usuario?",
-    "servers_apply_hint": "Los cambios en la asignación de servidores se aplican inmediatamente, no es necesario guardar",
     "delete_self_error_msg": "No puedes eliminarte a ti mismo"
   },
   "validation": {

--- a/internal/i18n/es.json
+++ b/internal/i18n/es.json
@@ -992,6 +992,10 @@
     "update_success_msg": "Usuario actualizado correctamente",
     "delete_success_msg": "Usuario eliminado correctamente",
     "privileges_saved_success_msg": "Privilegios guardados correctamente",
+    "server_attached_msg": "Servidor asignado",
+    "server_detached_msg": "Servidor desasignado",
+    "confirm_server_detach": "¿Desasignar el servidor del usuario?",
+    "servers_apply_hint": "Los cambios en la asignación de servidores se aplican inmediatamente, no es necesario guardar",
     "delete_self_error_msg": "No puedes eliminarte a ti mismo"
   },
   "validation": {

--- a/internal/i18n/ru.json
+++ b/internal/i18n/ru.json
@@ -998,7 +998,6 @@
     "server_attached_msg": "Сервер привязан",
     "server_detached_msg": "Сервер отвязан",
     "confirm_server_detach": "Отвязать сервер от пользователя?",
-    "servers_apply_hint": "Изменения привязки серверов применяются сразу, нажимать «Сохранить» не нужно",
     "delete_self_error_msg": "Вы не можете удалить себя"
   },
   "validation": {

--- a/internal/i18n/ru.json
+++ b/internal/i18n/ru.json
@@ -995,6 +995,10 @@
     "update_success_msg": "Пользователь успешно обновлён",
     "delete_success_msg": "Пользователь успешно удалён",
     "privileges_saved_success_msg": "Привилегии успешно сохранены",
+    "server_attached_msg": "Сервер привязан",
+    "server_detached_msg": "Сервер отвязан",
+    "confirm_server_detach": "Отвязать сервер от пользователя?",
+    "servers_apply_hint": "Изменения привязки серверов применяются сразу, нажимать «Сохранить» не нужно",
     "delete_self_error_msg": "Вы не можете удалить себя"
   },
   "validation": {

--- a/internal/repositories/contracts.go
+++ b/internal/repositories/contracts.go
@@ -107,6 +107,10 @@ type ServerRepository interface {
 
 	SetUserServers(ctx context.Context, userID uint, serverIDs []uint) error
 
+	AttachUserServer(ctx context.Context, userID uint, serverID uint) error
+
+	DetachUserServer(ctx context.Context, userID uint, serverID uint) error
+
 	Exists(ctx context.Context, filter *filters.FindServer) (bool, error)
 
 	Search(ctx context.Context, query string) ([]*domain.Server, error)

--- a/internal/repositories/inmemory/servers.go
+++ b/internal/repositories/inmemory/servers.go
@@ -89,6 +89,20 @@ func (r *ServerRepository) SetUserServers(_ context.Context, userID uint, server
 	return nil
 }
 
+// AttachUserServer assigns the server to the user, keeping a single relation.
+func (r *ServerRepository) AttachUserServer(_ context.Context, userID uint, serverID uint) error {
+	r.AddUserServer(userID, serverID)
+
+	return nil
+}
+
+// DetachUserServer removes the server assignment from the user.
+func (r *ServerRepository) DetachUserServer(_ context.Context, userID uint, serverID uint) error {
+	r.RemoveUserServer(userID, serverID)
+
+	return nil
+}
+
 func (r *ServerRepository) Exists(_ context.Context, filter *filters.FindServer) (bool, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()

--- a/internal/repositories/mysql/server_user_migration_023_test.go
+++ b/internal/repositories/mysql/server_user_migration_023_test.go
@@ -1,0 +1,27 @@
+package mysql_test
+
+import (
+	"database/sql"
+	"os"
+	"testing"
+
+	repotesting "github.com/gameap/gameap/internal/repositories/testing"
+	_ "github.com/go-sql-driver/mysql" // MySQL driver
+	"github.com/stretchr/testify/require"
+)
+
+func TestServerUserMigration023EnforcesUniquePairs(t *testing.T) {
+	testMySQLDSN := os.Getenv("TEST_MYSQL_DSN")
+	if testMySQLDSN == "" {
+		t.Skip("Skipping MySQL tests because TEST_MYSQL_DSN is not set")
+	}
+
+	db, err := sql.Open("mysql", testMySQLDSN)
+	require.NoError(t, err)
+
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+
+	clearTestDB(t, db)
+
+	repotesting.RunServerUserUniqueMigrationTest(t, db, "mysql")
+}

--- a/internal/repositories/mysql/servers.go
+++ b/internal/repositories/mysql/servers.go
@@ -421,6 +421,51 @@ func (r *ServerRepository) SetUserServers(ctx context.Context, userID uint, serv
 	})
 }
 
+// AttachUserServer assigns the server to the user. server_user has no
+// unique constraint, so the pair is deleted and re-inserted in one
+// transaction to keep the operation idempotent with a single row.
+func (r *ServerRepository) AttachUserServer(ctx context.Context, userID uint, serverID uint) error {
+	return r.tm.Do(ctx, func(ctx context.Context) error {
+		err := r.DetachUserServer(ctx, userID, serverID)
+		if err != nil {
+			return err
+		}
+
+		insertQuery, insertArgs, err := sq.Insert("server_user").
+			Columns("user_id", "server_id").
+			Values(userID, serverID).
+			PlaceholderFormat(sq.Question).
+			ToSql()
+		if err != nil {
+			return errors.WithMessage(err, "failed to build insert query")
+		}
+
+		_, err = r.db.ExecContext(ctx, insertQuery, insertArgs...)
+		if err != nil {
+			return errors.WithMessage(err, "failed to insert relationship")
+		}
+
+		return nil
+	})
+}
+
+func (r *ServerRepository) DetachUserServer(ctx context.Context, userID uint, serverID uint) error {
+	deleteQuery, deleteArgs, err := sq.Delete("server_user").
+		Where(sq.Eq{"user_id": userID, "server_id": serverID}).
+		PlaceholderFormat(sq.Question).
+		ToSql()
+	if err != nil {
+		return errors.WithMessage(err, "failed to build delete query")
+	}
+
+	_, err = r.db.ExecContext(ctx, deleteQuery, deleteArgs...)
+	if err != nil {
+		return errors.WithMessage(err, "failed to delete relationship")
+	}
+
+	return nil
+}
+
 func (r *ServerRepository) Count(ctx context.Context, filter *filters.FindServer) (int, error) {
 	query, args, err := sq.Select("COUNT(*)").
 		From(base.ServersTable).

--- a/internal/repositories/mysql/servers.go
+++ b/internal/repositories/mysql/servers.go
@@ -400,7 +400,8 @@ func (r *ServerRepository) SetUserServers(ctx context.Context, userID uint, serv
 		if len(serverIDs) > 0 {
 			insertBuilder := sq.Insert("server_user").
 				Columns("user_id", "server_id").
-				PlaceholderFormat(sq.Question)
+				PlaceholderFormat(sq.Question).
+				Suffix("ON DUPLICATE KEY UPDATE server_id = server_id")
 
 			for _, serverID := range serverIDs {
 				insertBuilder = insertBuilder.Values(userID, serverID)
@@ -421,32 +422,26 @@ func (r *ServerRepository) SetUserServers(ctx context.Context, userID uint, serv
 	})
 }
 
-// AttachUserServer assigns the server to the user. server_user has no
-// unique constraint, so the pair is deleted and re-inserted in one
-// transaction to keep the operation idempotent with a single row.
+// AttachUserServer assigns the server to the user. The unique
+// (user_id, server_id) index makes the insert idempotent: a repeated
+// or concurrent attach keeps a single row.
 func (r *ServerRepository) AttachUserServer(ctx context.Context, userID uint, serverID uint) error {
-	return r.tm.Do(ctx, func(ctx context.Context) error {
-		err := r.DetachUserServer(ctx, userID, serverID)
-		if err != nil {
-			return err
-		}
+	query, args, err := sq.Insert("server_user").
+		Columns("user_id", "server_id").
+		Values(userID, serverID).
+		Suffix("ON DUPLICATE KEY UPDATE server_id = server_id").
+		PlaceholderFormat(sq.Question).
+		ToSql()
+	if err != nil {
+		return errors.WithMessage(err, "failed to build insert query")
+	}
 
-		insertQuery, insertArgs, err := sq.Insert("server_user").
-			Columns("user_id", "server_id").
-			Values(userID, serverID).
-			PlaceholderFormat(sq.Question).
-			ToSql()
-		if err != nil {
-			return errors.WithMessage(err, "failed to build insert query")
-		}
+	_, err = r.db.ExecContext(ctx, query, args...)
+	if err != nil {
+		return errors.WithMessage(err, "failed to insert relationship")
+	}
 
-		_, err = r.db.ExecContext(ctx, insertQuery, insertArgs...)
-		if err != nil {
-			return errors.WithMessage(err, "failed to insert relationship")
-		}
-
-		return nil
-	})
+	return nil
 }
 
 func (r *ServerRepository) DetachUserServer(ctx context.Context, userID uint, serverID uint) error {

--- a/internal/repositories/postgres/server_user_migration_023_test.go
+++ b/internal/repositories/postgres/server_user_migration_023_test.go
@@ -1,0 +1,27 @@
+package postgres_test
+
+import (
+	"database/sql"
+	"os"
+	"testing"
+
+	repotesting "github.com/gameap/gameap/internal/repositories/testing"
+	_ "github.com/jackc/pgx/v5/stdlib" // PostgreSQL driver
+	"github.com/stretchr/testify/require"
+)
+
+func TestServerUserMigration023EnforcesUniquePairs(t *testing.T) {
+	testPostgresDSN := os.Getenv("TEST_POSTGRES_DSN")
+	if testPostgresDSN == "" {
+		t.Skip("Skipping PostgreSQL tests because TEST_POSTGRES_DSN is not set")
+	}
+
+	db, err := sql.Open("pgx", testPostgresDSN)
+	require.NoError(t, err)
+
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+
+	clearTestDB(t, db)
+
+	repotesting.RunServerUserUniqueMigrationTest(t, db, "postgres")
+}

--- a/internal/repositories/postgres/servers.go
+++ b/internal/repositories/postgres/servers.go
@@ -575,7 +575,8 @@ func (r *ServerRepository) SetUserServers(ctx context.Context, userID uint, serv
 		if len(serverIDs) > 0 {
 			insertBuilder := sq.Insert("server_user").
 				Columns("user_id", "server_id").
-				PlaceholderFormat(sq.Dollar)
+				PlaceholderFormat(sq.Dollar).
+				Suffix("ON CONFLICT (user_id, server_id) DO NOTHING")
 
 			for _, serverID := range serverIDs {
 				insertBuilder = insertBuilder.Values(userID, serverID)
@@ -596,32 +597,26 @@ func (r *ServerRepository) SetUserServers(ctx context.Context, userID uint, serv
 	})
 }
 
-// AttachUserServer assigns the server to the user. server_user has no
-// unique constraint, so the pair is deleted and re-inserted in one
-// transaction to keep the operation idempotent with a single row.
+// AttachUserServer assigns the server to the user. The unique
+// (user_id, server_id) index makes the insert idempotent: a repeated
+// or concurrent attach keeps a single row.
 func (r *ServerRepository) AttachUserServer(ctx context.Context, userID uint, serverID uint) error {
-	return r.tm.Do(ctx, func(ctx context.Context) error {
-		err := r.DetachUserServer(ctx, userID, serverID)
-		if err != nil {
-			return err
-		}
+	query, args, err := sq.Insert("server_user").
+		Columns("user_id", "server_id").
+		Values(userID, serverID).
+		Suffix("ON CONFLICT (user_id, server_id) DO NOTHING").
+		PlaceholderFormat(sq.Dollar).
+		ToSql()
+	if err != nil {
+		return errors.WithMessage(err, "failed to build insert query")
+	}
 
-		insertQuery, insertArgs, err := sq.Insert("server_user").
-			Columns("user_id", "server_id").
-			Values(userID, serverID).
-			PlaceholderFormat(sq.Dollar).
-			ToSql()
-		if err != nil {
-			return errors.WithMessage(err, "failed to build insert query")
-		}
+	_, err = r.db.ExecContext(ctx, query, args...)
+	if err != nil {
+		return errors.WithMessage(err, "failed to insert relationship")
+	}
 
-		_, err = r.db.ExecContext(ctx, insertQuery, insertArgs...)
-		if err != nil {
-			return errors.WithMessage(err, "failed to insert relationship")
-		}
-
-		return nil
-	})
+	return nil
 }
 
 func (r *ServerRepository) DetachUserServer(ctx context.Context, userID uint, serverID uint) error {

--- a/internal/repositories/postgres/servers.go
+++ b/internal/repositories/postgres/servers.go
@@ -596,6 +596,51 @@ func (r *ServerRepository) SetUserServers(ctx context.Context, userID uint, serv
 	})
 }
 
+// AttachUserServer assigns the server to the user. server_user has no
+// unique constraint, so the pair is deleted and re-inserted in one
+// transaction to keep the operation idempotent with a single row.
+func (r *ServerRepository) AttachUserServer(ctx context.Context, userID uint, serverID uint) error {
+	return r.tm.Do(ctx, func(ctx context.Context) error {
+		err := r.DetachUserServer(ctx, userID, serverID)
+		if err != nil {
+			return err
+		}
+
+		insertQuery, insertArgs, err := sq.Insert("server_user").
+			Columns("user_id", "server_id").
+			Values(userID, serverID).
+			PlaceholderFormat(sq.Dollar).
+			ToSql()
+		if err != nil {
+			return errors.WithMessage(err, "failed to build insert query")
+		}
+
+		_, err = r.db.ExecContext(ctx, insertQuery, insertArgs...)
+		if err != nil {
+			return errors.WithMessage(err, "failed to insert relationship")
+		}
+
+		return nil
+	})
+}
+
+func (r *ServerRepository) DetachUserServer(ctx context.Context, userID uint, serverID uint) error {
+	deleteQuery, deleteArgs, err := sq.Delete("server_user").
+		Where(sq.Eq{"user_id": userID, "server_id": serverID}).
+		PlaceholderFormat(sq.Dollar).
+		ToSql()
+	if err != nil {
+		return errors.WithMessage(err, "failed to build delete query")
+	}
+
+	_, err = r.db.ExecContext(ctx, deleteQuery, deleteArgs...)
+	if err != nil {
+		return errors.WithMessage(err, "failed to delete relationship")
+	}
+
+	return nil
+}
+
 func (r *ServerRepository) Count(ctx context.Context, filter *filters.FindServer) (int, error) {
 	query, args, err := sq.Select("COUNT(*)").
 		From(base.ServersTable).

--- a/internal/repositories/sqlite/server_user_migration_023_test.go
+++ b/internal/repositories/sqlite/server_user_migration_023_test.go
@@ -1,0 +1,20 @@
+package sqlite_test
+
+import (
+	"database/sql"
+	"testing"
+
+	repotesting "github.com/gameap/gameap/internal/repositories/testing"
+	"github.com/stretchr/testify/require"
+)
+
+func TestServerUserMigration023EnforcesUniquePairs(t *testing.T) {
+	// A private in-memory database: the shared one used by the other tests
+	// is already migrated past the version this test has to stop at.
+	db, err := sql.Open("sqlite", "file:migration023?mode=memory&cache=shared")
+	require.NoError(t, err)
+
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+
+	repotesting.RunServerUserUniqueMigrationTest(t, db, "sqlite")
+}

--- a/internal/repositories/sqlite/servers.go
+++ b/internal/repositories/sqlite/servers.go
@@ -403,7 +403,8 @@ func (r *ServerRepository) SetUserServers(ctx context.Context, userID uint, serv
 
 		if len(serverIDs) > 0 {
 			insertBuilder := sq.Insert("server_user").
-				Columns("user_id", "server_id")
+				Columns("user_id", "server_id").
+				Suffix("ON CONFLICT (user_id, server_id) DO NOTHING")
 
 			for _, serverID := range serverIDs {
 				insertBuilder = insertBuilder.Values(userID, serverID)
@@ -424,31 +425,25 @@ func (r *ServerRepository) SetUserServers(ctx context.Context, userID uint, serv
 	})
 }
 
-// AttachUserServer assigns the server to the user. server_user has no
-// unique constraint, so the pair is deleted and re-inserted in one
-// transaction to keep the operation idempotent with a single row.
+// AttachUserServer assigns the server to the user. The unique
+// (user_id, server_id) index makes the insert idempotent: a repeated
+// or concurrent attach keeps a single row.
 func (r *ServerRepository) AttachUserServer(ctx context.Context, userID uint, serverID uint) error {
-	return r.tm.Do(ctx, func(ctx context.Context) error {
-		err := r.DetachUserServer(ctx, userID, serverID)
-		if err != nil {
-			return err
-		}
+	query, args, err := sq.Insert("server_user").
+		Columns("user_id", "server_id").
+		Values(userID, serverID).
+		Suffix("ON CONFLICT (user_id, server_id) DO NOTHING").
+		ToSql()
+	if err != nil {
+		return errors.WithMessage(err, "failed to build insert query")
+	}
 
-		insertQuery, insertArgs, err := sq.Insert("server_user").
-			Columns("user_id", "server_id").
-			Values(userID, serverID).
-			ToSql()
-		if err != nil {
-			return errors.WithMessage(err, "failed to build insert query")
-		}
+	_, err = r.db.ExecContext(ctx, query, args...)
+	if err != nil {
+		return errors.WithMessage(err, "failed to insert relationship")
+	}
 
-		_, err = r.db.ExecContext(ctx, insertQuery, insertArgs...)
-		if err != nil {
-			return errors.WithMessage(err, "failed to insert relationship")
-		}
-
-		return nil
-	})
+	return nil
 }
 
 func (r *ServerRepository) DetachUserServer(ctx context.Context, userID uint, serverID uint) error {

--- a/internal/repositories/sqlite/servers.go
+++ b/internal/repositories/sqlite/servers.go
@@ -424,6 +424,49 @@ func (r *ServerRepository) SetUserServers(ctx context.Context, userID uint, serv
 	})
 }
 
+// AttachUserServer assigns the server to the user. server_user has no
+// unique constraint, so the pair is deleted and re-inserted in one
+// transaction to keep the operation idempotent with a single row.
+func (r *ServerRepository) AttachUserServer(ctx context.Context, userID uint, serverID uint) error {
+	return r.tm.Do(ctx, func(ctx context.Context) error {
+		err := r.DetachUserServer(ctx, userID, serverID)
+		if err != nil {
+			return err
+		}
+
+		insertQuery, insertArgs, err := sq.Insert("server_user").
+			Columns("user_id", "server_id").
+			Values(userID, serverID).
+			ToSql()
+		if err != nil {
+			return errors.WithMessage(err, "failed to build insert query")
+		}
+
+		_, err = r.db.ExecContext(ctx, insertQuery, insertArgs...)
+		if err != nil {
+			return errors.WithMessage(err, "failed to insert relationship")
+		}
+
+		return nil
+	})
+}
+
+func (r *ServerRepository) DetachUserServer(ctx context.Context, userID uint, serverID uint) error {
+	deleteQuery, deleteArgs, err := sq.Delete("server_user").
+		Where(sq.Eq{"user_id": userID, "server_id": serverID}).
+		ToSql()
+	if err != nil {
+		return errors.WithMessage(err, "failed to build delete query")
+	}
+
+	_, err = r.db.ExecContext(ctx, deleteQuery, deleteArgs...)
+	if err != nil {
+		return errors.WithMessage(err, "failed to delete relationship")
+	}
+
+	return nil
+}
+
 func (r *ServerRepository) Count(ctx context.Context, filter *filters.FindServer) (int, error) {
 	query, args, err := sq.Select("COUNT(*)").
 		From(base.ServersTable).

--- a/internal/repositories/testing/server_user_migration_023.go
+++ b/internal/repositories/testing/server_user_migration_023.go
@@ -1,0 +1,126 @@
+package testing
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	sq "github.com/Masterminds/squirrel"
+	"github.com/gameap/gameap/internal/config"
+	"github.com/gameap/gameap/migrations"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	serverUserUniqueVersion       = 23
+	versionBeforeServerUserUnique = serverUserUniqueVersion - 1
+)
+
+// RunServerUserUniqueMigrationTest checks migration 023 on a real database:
+// duplicate (user_id, server_id) pairs an installation accumulated while the
+// table had no uniqueness are collapsed to one row each, distinct pairs all
+// survive, and the new unique index refuses a plain duplicate insert -- the
+// guarantee AttachUserServer's conflict-safe insert relies on. db must be
+// empty; driver is the DATABASE_DRIVER value.
+func RunServerUserUniqueMigrationTest(t *testing.T, db *sql.DB, driver string) {
+	t.Helper()
+
+	ctx := context.Background()
+
+	provider, err := migrations.NewProvider(ctx, migrationContainer{
+		db:  db,
+		cfg: &config.Config{DatabaseDriver: driver},
+	})
+	require.NoError(t, err)
+
+	_, err = provider.UpTo(ctx, versionBeforeServerUserUnique)
+	require.NoError(t, err)
+
+	seeds := [][2]int64{
+		{7001, 1}, {7001, 1}, {7001, 1},
+		{7001, 2},
+		{7002, 1}, {7002, 1},
+		{7003, 3},
+	}
+	for _, pair := range seeds {
+		seedServerUserRow(ctx, t, db, driver, pair[0], pair[1])
+	}
+
+	_, err = provider.Up(ctx)
+	require.NoError(t, err)
+
+	wantPairs := [][2]int64{
+		{7001, 1},
+		{7001, 2},
+		{7002, 1},
+		{7003, 3},
+	}
+	assert.Equal(t, wantPairs, readServerUserPairs(ctx, t, db, driver),
+		"duplicates must collapse to one row, distinct pairs must all survive")
+
+	// From here on the index, not the application, holds the invariant.
+	query, args, err := sq.Insert("server_user").
+		Columns("user_id", "server_id").
+		Values(7003, 3).
+		PlaceholderFormat(driverPlaceholders(driver)).
+		ToSql()
+	require.NoError(t, err)
+
+	_, err = db.ExecContext(ctx, query, args...)
+	require.Error(t, err, "the unique index must refuse a plain duplicate insert")
+}
+
+func seedServerUserRow(
+	ctx context.Context,
+	t *testing.T,
+	db *sql.DB,
+	driver string,
+	userID int64,
+	serverID int64,
+) {
+	t.Helper()
+
+	query, args, err := sq.Insert("server_user").
+		Columns("user_id", "server_id").
+		Values(userID, serverID).
+		PlaceholderFormat(driverPlaceholders(driver)).
+		ToSql()
+	require.NoError(t, err)
+
+	_, err = db.ExecContext(ctx, query, args...)
+	require.NoErrorf(t, err, "seeding pair (%d, %d)", userID, serverID)
+}
+
+func readServerUserPairs(
+	ctx context.Context,
+	t *testing.T,
+	db *sql.DB,
+	driver string,
+) [][2]int64 {
+	t.Helper()
+
+	query, _, err := sq.Select("user_id", "server_id").From("server_user").
+		OrderBy("user_id", "server_id").
+		PlaceholderFormat(driverPlaceholders(driver)).
+		ToSql()
+	require.NoError(t, err)
+
+	rows, err := db.QueryContext(ctx, query)
+	require.NoError(t, err)
+
+	defer func() { _ = rows.Close() }()
+
+	var pairs [][2]int64
+
+	for rows.Next() {
+		var userID, serverID int64
+		require.NoError(t, rows.Scan(&userID, &serverID))
+
+		pairs = append(pairs, [2]int64{userID, serverID})
+	}
+
+	require.NoError(t, rows.Err())
+
+	return pairs
+}

--- a/internal/repositories/testing/servers_suite.go
+++ b/internal/repositories/testing/servers_suite.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/sync/errgroup"
+
 	"github.com/gameap/gameap/internal/domain"
 	"github.com/gameap/gameap/internal/filters"
 	"github.com/gameap/gameap/internal/repositories"
@@ -1867,7 +1869,40 @@ func (s *ServerRepositorySuite) TestServerRepositoryAttachUserServer() {
 		results, err := s.repo.FindUserServers(ctx, 4102, nil, nil, nil)
 		require.NoError(t, err)
 		require.Len(t, results, 2)
+		assert.ElementsMatch(t, []uint{server1.ID, server2.ID},
+			[]uint{results[0].ID, results[1].ID},
+			"both the old and the new relation must be present")
 	})
+}
+
+func (s *ServerRepositorySuite) TestServerRepositoryAttachUserServerConcurrent() {
+	ctx := context.Background()
+
+	server := &domain.Server{
+		UID:        uuid.New(),
+		UUIDShort:  "attachc",
+		Name:       "Attach Concurrent Server",
+		GameID:     "csgo",
+		DSID:       1,
+		ServerIP:   "192.168.6.5",
+		ServerPort: 27015,
+		Dir:        "/servers/attachc",
+	}
+	require.NoError(s.T(), s.repo.Save(ctx, server))
+
+	var eg errgroup.Group
+	for range 8 {
+		eg.Go(func() error {
+			return s.repo.AttachUserServer(ctx, 4120, server.ID)
+		})
+	}
+	require.NoError(s.T(), eg.Wait())
+
+	results, err := s.repo.FindUserServers(ctx, 4120, nil, nil, nil)
+	require.NoError(s.T(), err)
+	require.Len(s.T(), results, 1,
+		"concurrent attaches of the same pair must keep a single relation")
+	assert.Equal(s.T(), server.ID, results[0].ID)
 }
 
 func (s *ServerRepositorySuite) TestServerRepositoryDetachUserServer() {
@@ -1937,6 +1972,7 @@ func (s *ServerRepositorySuite) TestServerRepositoryDetachUserServer() {
 		otherResults, err := s.repo.FindUserServers(ctx, 4112, nil, nil, nil)
 		require.NoError(t, err)
 		require.Len(t, otherResults, 1, "other users' relations to the same server must survive")
+		assert.Equal(t, server1.ID, otherResults[0].ID)
 	})
 
 	s.T().Run("detach_nonexistent_relation_is_noop", func(t *testing.T) {

--- a/internal/repositories/testing/servers_suite.go
+++ b/internal/repositories/testing/servers_suite.go
@@ -1782,6 +1782,176 @@ func (s *ServerRepositorySuite) TestServerRepositoryRemoveUserServer() {
 	})
 }
 
+func (s *ServerRepositorySuite) TestServerRepositoryAttachUserServer() {
+	ctx := context.Background()
+
+	s.T().Run("attach_new_relation", func(t *testing.T) {
+		// ARRANGE
+		server := &domain.Server{
+			UID:        uuid.New(),
+			UUIDShort:  "attach1",
+			Name:       "Attach Link Server",
+			GameID:     "csgo",
+			DSID:       1,
+			ServerIP:   "192.168.6.1",
+			ServerPort: 27015,
+			Dir:        "/servers/attach1",
+		}
+		require.NoError(t, s.repo.Save(ctx, server))
+
+		// ACT
+		require.NoError(t, s.repo.AttachUserServer(ctx, 4100, server.ID))
+
+		// ASSERT
+		results, err := s.repo.FindUserServers(ctx, 4100, nil, nil, nil)
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		assert.Equal(t, server.ID, results[0].ID)
+	})
+
+	s.T().Run("attach_twice_keeps_single_relation", func(t *testing.T) {
+		// ARRANGE
+		server := &domain.Server{
+			UID:        uuid.New(),
+			UUIDShort:  "attach2",
+			Name:       "Attach Twice Server",
+			GameID:     "csgo",
+			DSID:       1,
+			ServerIP:   "192.168.6.2",
+			ServerPort: 27015,
+			Dir:        "/servers/attach2",
+		}
+		require.NoError(t, s.repo.Save(ctx, server))
+		require.NoError(t, s.repo.AttachUserServer(ctx, 4101, server.ID))
+
+		// ACT
+		require.NoError(t, s.repo.AttachUserServer(ctx, 4101, server.ID))
+
+		// ASSERT
+		results, err := s.repo.FindUserServers(ctx, 4101, nil, nil, nil)
+		require.NoError(t, err)
+		require.Len(t, results, 1, "repeated attach must keep a single relation")
+		assert.Equal(t, server.ID, results[0].ID)
+	})
+
+	s.T().Run("attach_keeps_other_relations", func(t *testing.T) {
+		// ARRANGE
+		server1 := &domain.Server{
+			UID:        uuid.New(),
+			UUIDShort:  "attach3",
+			Name:       "Attach Keep Server 1",
+			GameID:     "csgo",
+			DSID:       1,
+			ServerIP:   "192.168.6.3",
+			ServerPort: 27015,
+			Dir:        "/servers/attach3",
+		}
+		server2 := &domain.Server{
+			UID:        uuid.New(),
+			UUIDShort:  "attach4",
+			Name:       "Attach Keep Server 2",
+			GameID:     "minecraft",
+			DSID:       1,
+			ServerIP:   "192.168.6.4",
+			ServerPort: 25565,
+			Dir:        "/servers/attach4",
+		}
+		require.NoError(t, s.repo.Save(ctx, server1))
+		require.NoError(t, s.repo.Save(ctx, server2))
+		require.NoError(t, s.repo.AttachUserServer(ctx, 4102, server1.ID))
+
+		// ACT
+		require.NoError(t, s.repo.AttachUserServer(ctx, 4102, server2.ID))
+
+		// ASSERT
+		results, err := s.repo.FindUserServers(ctx, 4102, nil, nil, nil)
+		require.NoError(t, err)
+		require.Len(t, results, 2)
+	})
+}
+
+func (s *ServerRepositorySuite) TestServerRepositoryDetachUserServer() {
+	ctx := context.Background()
+
+	s.T().Run("detach_existing_relation", func(t *testing.T) {
+		// ARRANGE
+		server := &domain.Server{
+			UID:        uuid.New(),
+			UUIDShort:  "detach1",
+			Name:       "Detach Link Server",
+			GameID:     "csgo",
+			DSID:       1,
+			ServerIP:   "192.168.7.1",
+			ServerPort: 27015,
+			Dir:        "/servers/detach1",
+		}
+		require.NoError(t, s.repo.Save(ctx, server))
+		require.NoError(t, s.repo.AttachUserServer(ctx, 4110, server.ID))
+
+		// ACT
+		require.NoError(t, s.repo.DetachUserServer(ctx, 4110, server.ID))
+
+		// ASSERT
+		results, err := s.repo.FindUserServers(ctx, 4110, nil, nil, nil)
+		require.NoError(t, err)
+		assert.Empty(t, results)
+	})
+
+	s.T().Run("detach_only_requested_pair", func(t *testing.T) {
+		// ARRANGE
+		server1 := &domain.Server{
+			UID:        uuid.New(),
+			UUIDShort:  "detach2",
+			Name:       "Detach Pair Server 1",
+			GameID:     "csgo",
+			DSID:       1,
+			ServerIP:   "192.168.7.2",
+			ServerPort: 27015,
+			Dir:        "/servers/detach2",
+		}
+		server2 := &domain.Server{
+			UID:        uuid.New(),
+			UUIDShort:  "detach3",
+			Name:       "Detach Pair Server 2",
+			GameID:     "minecraft",
+			DSID:       1,
+			ServerIP:   "192.168.7.3",
+			ServerPort: 25565,
+			Dir:        "/servers/detach3",
+		}
+		require.NoError(t, s.repo.Save(ctx, server1))
+		require.NoError(t, s.repo.Save(ctx, server2))
+		require.NoError(t, s.repo.AttachUserServer(ctx, 4111, server1.ID))
+		require.NoError(t, s.repo.AttachUserServer(ctx, 4111, server2.ID))
+		require.NoError(t, s.repo.AttachUserServer(ctx, 4112, server1.ID))
+
+		// ACT
+		require.NoError(t, s.repo.DetachUserServer(ctx, 4111, server1.ID))
+
+		// ASSERT
+		results, err := s.repo.FindUserServers(ctx, 4111, nil, nil, nil)
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		assert.Equal(t, server2.ID, results[0].ID, "only the detached pair must disappear")
+
+		otherResults, err := s.repo.FindUserServers(ctx, 4112, nil, nil, nil)
+		require.NoError(t, err)
+		require.Len(t, otherResults, 1, "other users' relations to the same server must survive")
+	})
+
+	s.T().Run("detach_nonexistent_relation_is_noop", func(t *testing.T) {
+		// ACT
+		err := s.repo.DetachUserServer(ctx, 4113, 99999)
+
+		// ASSERT
+		require.NoError(t, err)
+
+		results, err := s.repo.FindUserServers(ctx, 4113, nil, nil, nil)
+		require.NoError(t, err)
+		assert.Empty(t, results)
+	})
+}
+
 func (s *ServerRepositorySuite) TestServerRepositoryPagination() {
 	ctx := context.Background()
 

--- a/internal/services/taskdispatcher/dispatcher_test.go
+++ b/internal/services/taskdispatcher/dispatcher_test.go
@@ -224,6 +224,8 @@ func (r *fakeServerRepo) SaveBulk(_ context.Context, _ []*domain.Server) error  
 func (r *fakeServerRepo) Delete(_ context.Context, _ uint) error                   { return nil }
 func (r *fakeServerRepo) SoftDelete(_ context.Context, _ uint) error               { return nil }
 func (r *fakeServerRepo) SetUserServers(_ context.Context, _ uint, _ []uint) error { return nil }
+func (r *fakeServerRepo) AttachUserServer(_ context.Context, _ uint, _ uint) error { return nil }
+func (r *fakeServerRepo) DetachUserServer(_ context.Context, _ uint, _ uint) error { return nil }
 func (r *fakeServerRepo) Exists(_ context.Context, _ *filters.FindServer) (bool, error) {
 	return false, nil
 }

--- a/migrations/mysql/023_server_user_unique.sql
+++ b/migrations/mysql/023_server_user_unique.sql
@@ -1,0 +1,29 @@
+-- +goose Up
+
+-- server_user carried no uniqueness, so two concurrent attaches of the same
+-- pair could each pass the delete-then-insert dance and leave duplicate rows.
+-- Collapse whatever duplicates an installation already holds, then let a
+-- unique key carry idempotency: AttachUserServer now inserts with
+-- ON DUPLICATE KEY UPDATE against it. The table has no primary key, so rows
+-- of a duplicated pair are indistinguishable; a temporary auto-increment id
+-- tells them apart for the delete and is dropped right after.
+
+ALTER TABLE server_user ADD COLUMN dedup_id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY;
+
+DELETE stale FROM server_user AS stale
+JOIN (
+    SELECT MIN(dedup_id) AS keep_id, user_id, server_id
+    FROM server_user
+    GROUP BY user_id, server_id
+) AS keep
+    ON keep.user_id = stale.user_id
+   AND keep.server_id = stale.server_id
+WHERE stale.dedup_id <> keep.keep_id;
+
+ALTER TABLE server_user DROP COLUMN dedup_id;
+
+ALTER TABLE server_user ADD UNIQUE KEY server_user_user_id_server_id_unique (user_id, server_id);
+
+-- +goose Down
+
+ALTER TABLE server_user DROP KEY server_user_user_id_server_id_unique;

--- a/migrations/postgres/023_server_user_unique.sql
+++ b/migrations/postgres/023_server_user_unique.sql
@@ -7,6 +7,15 @@
 -- ON CONFLICT DO NOTHING against it. ROW_NUMBER instead of ctid ordering
 -- because tid comparison operators only exist since PostgreSQL 14.
 
+-- The panel is multi-instance: while this runs, another instance still on
+-- the previous version can be attaching pairs, and a row slipping in
+-- between the cleanup and the index build would abort the index build and
+-- the whole migration. Blocking writers until commit closes that window.
+-- SHARE ROW EXCLUSIVE rather than SHARE because it is self-exclusive: two
+-- instances migrating at once would both enter SHARE and then deadlock
+-- upgrading to the ACCESS EXCLUSIVE that CREATE INDEX takes.
+LOCK TABLE server_user IN SHARE ROW EXCLUSIVE MODE;
+
 DELETE FROM server_user
 WHERE ctid IN (
     SELECT ctid FROM (

--- a/migrations/postgres/023_server_user_unique.sql
+++ b/migrations/postgres/023_server_user_unique.sql
@@ -1,0 +1,25 @@
+-- +goose Up
+
+-- server_user carried no uniqueness, so two concurrent attaches of the same
+-- pair could each pass the delete-then-insert dance and leave duplicate rows.
+-- Collapse whatever duplicates an installation already holds, then let a
+-- unique index carry idempotency: AttachUserServer now inserts with
+-- ON CONFLICT DO NOTHING against it. ROW_NUMBER instead of ctid ordering
+-- because tid comparison operators only exist since PostgreSQL 14.
+
+DELETE FROM server_user
+WHERE ctid IN (
+    SELECT ctid FROM (
+        SELECT ctid,
+               ROW_NUMBER() OVER (PARTITION BY user_id, server_id) AS rn
+        FROM server_user
+    ) numbered
+    WHERE numbered.rn > 1
+);
+
+CREATE UNIQUE INDEX server_user_user_id_server_id_unique
+    ON server_user (user_id, server_id);
+
+-- +goose Down
+
+DROP INDEX server_user_user_id_server_id_unique;

--- a/migrations/sqlite/023_server_user_unique.sql
+++ b/migrations/sqlite/023_server_user_unique.sql
@@ -1,0 +1,21 @@
+-- +goose Up
+
+-- server_user carried no uniqueness, so two concurrent attaches of the same
+-- pair could each pass the delete-then-insert dance and leave duplicate rows.
+-- Collapse whatever duplicates an installation already holds, then let a
+-- unique index carry idempotency: AttachUserServer now inserts with
+-- ON CONFLICT DO NOTHING against it.
+
+DELETE FROM server_user
+WHERE rowid NOT IN (
+    SELECT MIN(rowid)
+    FROM server_user
+    GROUP BY user_id, server_id
+);
+
+CREATE UNIQUE INDEX server_user_user_id_server_id_unique
+    ON server_user (user_id, server_id);
+
+-- +goose Down
+
+DROP INDEX server_user_user_id_server_id_unique;

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -487,6 +487,8 @@ paths:
     $ref: './paths/users.yaml#/~1api~1users~1{id}'
   /api/users/{id}/servers:
     $ref: './paths/users.yaml#/~1api~1users~1{id}~1servers'
+  /api/users/{id}/servers/{server}:
+    $ref: './paths/users.yaml#/~1api~1users~1{id}~1servers~1{server}'
   /api/users/{id}/servers/{server}/permissions:
     $ref: './paths/users.yaml#/~1api~1users~1{id}~1servers~1{server}~1permissions'
 

--- a/openapi/paths/users.yaml
+++ b/openapi/paths/users.yaml
@@ -262,6 +262,87 @@
             schema:
               $ref: '../schemas/ErrorResponse.yaml'
 
+/api/users/{id}/servers/{server}:
+  put:
+    tags:
+      - Users
+    summary: Attach server to user
+    description: |
+      Assigns the server to the user, granting access to it (Admin only).
+      Idempotent: attaching an already attached server succeeds and keeps
+      a single assignment.
+    operationId: attachUserServer
+    parameters:
+      - $ref: '../parameters/PathUserId.yaml'
+      - name: server
+        in: path
+        required: true
+        description: Server ID
+        schema:
+          type: integer
+    responses:
+      '204':
+        description: Server attached
+      '401':
+        description: Unauthorized
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/ErrorResponse.yaml'
+      '403':
+        description: Forbidden
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/ErrorResponse.yaml'
+      '404':
+        description: Not found
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/ErrorResponse.yaml'
+
+  delete:
+    tags:
+      - Users
+    summary: Detach server from user
+    description: |
+      Removes the server assignment from the user (Admin only). Idempotent:
+      detaching a server that is not attached succeeds, and the server
+      itself is not required to exist, so stale assignments can be cleaned
+      up. Per-server permissions are kept and become effective again if
+      the server is re-attached.
+    operationId: detachUserServer
+    parameters:
+      - $ref: '../parameters/PathUserId.yaml'
+      - name: server
+        in: path
+        required: true
+        description: Server ID
+        schema:
+          type: integer
+    responses:
+      '204':
+        description: Server detached
+      '401':
+        description: Unauthorized
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/ErrorResponse.yaml'
+      '403':
+        description: Forbidden
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/ErrorResponse.yaml'
+      '404':
+        description: User not found
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/ErrorResponse.yaml'
+
 /api/users/{id}/servers/{server}/permissions:
   get:
     tags:

--- a/openapi/schemas/requests/CreateUserRequest.yaml
+++ b/openapi/schemas/requests/CreateUserRequest.yaml
@@ -35,6 +35,15 @@ properties:
     items:
       type: string
     example: ["user"]
+  servers:
+    type: array
+    description: |
+      Game server IDs assigned to the user. The list is replaced as a
+      whole on every request: omitting the field or sending an empty
+      array clears all assignments.
+    items:
+      type: integer
+    example: [1, 2]
 required:
   - login
   - email

--- a/openapi/schemas/requests/UpdateUserRequest.yaml
+++ b/openapi/schemas/requests/UpdateUserRequest.yaml
@@ -35,3 +35,12 @@ properties:
     items:
       type: string
     example: ["user"]
+  servers:
+    type: array
+    description: |
+      Game server IDs assigned to the user. The list is replaced as a
+      whole on every request: omitting the field or sending an empty
+      array clears all assignments.
+    items:
+      type: integer
+    example: [1, 2]

--- a/test/manual/users/DELETE_user_server.http
+++ b/test/manual/users/DELETE_user_server.http
@@ -1,0 +1,2 @@
+DELETE {{host}}/api/users/2/servers/1
+Authorization: Bearer {{authToken}}

--- a/test/manual/users/PUT_user_server.http
+++ b/test/manual/users/PUT_user_server.http
@@ -1,0 +1,2 @@
+PUT {{host}}/api/users/2/servers/1
+Authorization: Bearer {{authToken}}

--- a/web/frontend/js/components/servers/UserServerPrivileges.vue
+++ b/web/frontend/js/components/servers/UserServerPrivileges.vue
@@ -1,6 +1,5 @@
 <template>
     <div>
-        <p class="mb-3 text-sm text-stone-500 dark:text-stone-300">{{ trans('users.servers_apply_hint') }}</p>
         <div class="mb-4 overflow-x-auto">
             <GTable>
                 <thead>

--- a/web/frontend/js/components/servers/UserServerPrivileges.vue
+++ b/web/frontend/js/components/servers/UserServerPrivileges.vue
@@ -1,5 +1,6 @@
 <template>
     <div>
+        <p class="mb-3 text-sm text-stone-500 dark:text-stone-300">{{ trans('users.servers_apply_hint') }}</p>
         <div class="mb-4 overflow-x-auto">
             <GTable>
                 <thead>
@@ -23,7 +24,13 @@
                         <GButton color="blue" size="small" v-on:click="onClickEditPrivileges(server)">
                           <GIcon name="lock" />
                         </GButton>
-                        <GButton color="red" size="small" v-on:click="removeItem(itemIndex)">
+                        <GButton
+                            color="red"
+                            size="small"
+                            :loading="detachingServerId === server.id"
+                            data-testid="user-servers-row-remove"
+                            v-on:click="removeItem(itemIndex)"
+                        >
                             <GIcon name="close" />
                         </GButton>
                       </td>
@@ -34,7 +41,7 @@
 
         <div class="mt-6 mb-3">
           <div class="flex justify-center mt-2">
-            <GButton color="green" size="small" v-on:click="onClickAddServer">
+            <GButton color="green" size="small" data-testid="user-servers-add-open" v-on:click="onClickAddServer">
               <GIcon name="add" />&nbsp;{{ trans('main.add') }}
             </GButton>
           </div>
@@ -49,6 +56,7 @@
     <div class="md:w-full">
       <n-select
           v-model:value="selectedServer"
+          data-testid="user-servers-select"
           filterable
           :placeholder="trans('users.servers_privileges_placeholder')"
           :options="serversListOptions"
@@ -69,7 +77,7 @@
     </div>
 
     <div class="flex justify-center mt-2">
-      <GButton color="green" v-on:click="addItem">
+      <GButton color="green" :loading="attaching" data-testid="user-servers-add-confirm" v-on:click="addItem">
         <GIcon name="add" />&nbsp;{{ trans('main.add') }}
       </GButton>
     </div>
@@ -135,7 +143,7 @@ import GButton from "../GButton.vue";
 import { GIcon, GModal, GTable, GSwitch, GGameIcon } from '@gameap/ui';
 import {trans as systemTrans, trans} from "@/i18n/i18n";
 import {useUserStore} from "@/store/user";
-import {errorNotification, notification} from "@/parts/dialogs";
+import {confirm, errorNotification, notification} from "@/parts/dialogs";
 import {usePluginsStore} from "@/store/plugins";
 
 const locale = window.gameapLang || 'en'
@@ -160,6 +168,8 @@ const selectedServer = ref(null)
 const serverList = ref([])
 const serversListOptions = ref([])
 const loading = ref(false)
+const attaching = ref(false)
+const detachingServerId = ref(null)
 
 function existsItem(id) {
   for (let item of items.value) {
@@ -188,7 +198,26 @@ function removeListsElem(elemId) {
 }
 
 function removeItem(index) {
-  items.value.splice(index, 1);
+  const server = items.value[index];
+  if (!server || detachingServerId.value !== null) {
+    return;
+  }
+
+  confirm(trans('users.confirm_server_detach'), () => {
+    detachingServerId.value = server.id;
+
+    userStore.detachServer(server.id).then(() => {
+      const currentIndex = items.value.findIndex((item) => item.id === server.id);
+      if (currentIndex !== -1) {
+        items.value.splice(currentIndex, 1);
+      }
+      window.$message?.success(trans('users.server_detached_msg'));
+    }).catch((error) => {
+      errorNotification(error);
+    }).finally(() => {
+      detachingServerId.value = null;
+    });
+  });
 }
 
 function addItem() {
@@ -198,8 +227,6 @@ function addItem() {
     return;
   }
 
-  addServerModalEnabled.value = false;
-
   if (existsItem(selectedServer.value)) {
     notification(trans('servers.server_already_added'))
 
@@ -207,13 +234,24 @@ function addItem() {
   }
 
   const newItem = findItem(selectedServer.value);
+  if (!newItem || attaching.value) {
+    return;
+  }
 
-  if (newItem) {
+  attaching.value = true;
+
+  userStore.attachServer(newItem.id).then(() => {
     items.value.push(newItem);
 
     removeListsElem(newItem.id);
     selectedServer.value = null;
-  }
+    addServerModalEnabled.value = false;
+    window.$message?.success(trans('users.server_attached_msg'));
+  }).catch((error) => {
+    errorNotification(error);
+  }).finally(() => {
+    attaching.value = false;
+  });
 }
 
 let timer

--- a/web/frontend/js/store/user.js
+++ b/web/frontend/js/store/user.js
@@ -51,6 +51,14 @@ export const useUserStore = defineStore('user', {
                 this.apiProcesses--
             }
         },
+        // No apiProcesses here: the store-wide loading getter would hide the
+        // whole servers card during these quick inline operations.
+        async attachServer(serverId) {
+            await axios.put('/api/users/'+this.userId+'/servers/'+serverId)
+        },
+        async detachServer(serverId) {
+            await axios.delete('/api/users/'+this.userId+'/servers/'+serverId)
+        },
         async fetchPermissionsForServer(serverId) {
             this.apiProcesses++
             try {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Admins can attach or detach individual servers from user accounts.
  - User creation and editing support assigning multiple servers.
  - Server changes apply immediately with confirmations, loading indicators, and success or error feedback.
  - Server assignments are idempotent and support stale-association cleanup.

- **Documentation**
  - Added API documentation for server assignment and removal endpoints.

- **Localization**
  - Added translations for server assignment actions in English, German, Spanish, and Russian.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->