### PR TITLE
add cli version

### DIFF
--- a/cmd/gameap/main.go
+++ b/cmd/gameap/main.go
@@ -2,9 +2,13 @@ package main
 
 import (
 	"flag"
+	"fmt"
+	"io"
 	"log/slog"
+	"os"
 
 	"github.com/gameap/gameap/internal/application"
+	"github.com/gameap/gameap/internal/application/defaults"
 
 	_ "github.com/go-sql-driver/mysql"
 	_ "github.com/jackc/pgx/v5/stdlib"
@@ -12,13 +16,37 @@ import (
 )
 
 func main() {
+	if isVersionCommand(os.Args[1:]) {
+		printVersion(os.Stdout)
+
+		return
+	}
+
 	envFile := flag.String("env", "", "Path to environment file")
+	showVersion := flag.Bool("version", false, "Print version information and exit")
 
 	flag.Parse()
+
+	if *showVersion {
+		printVersion(os.Stdout)
+
+		return
+	}
 
 	slog.Info("Starting ...")
 
 	application.Run(application.RunParams{
 		EnvFile: *envFile,
 	})
+}
+
+// isVersionCommand recognizes the bare `gameap version` form. The `-version`
+// and `--version` flag forms are handled by the flag package itself.
+func isVersionCommand(args []string) bool {
+	return len(args) > 0 && args[0] == "version"
+}
+
+func printVersion(w io.Writer) {
+	fmt.Fprintf(w, "GameAP %s\n", defaults.Version)
+	fmt.Fprintf(w, "Build date: %s\n", defaults.BuildDate)
 }

--- a/cmd/gameap/main_test.go
+++ b/cmd/gameap/main_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/gameap/gameap/internal/application/defaults"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsVersionCommand(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{name: "no_args", args: nil, want: false},
+		{name: "version_command", args: []string{"version"}, want: true},
+		{name: "version_command_with_extra_args", args: []string{"version", "--env", ".env"}, want: true},
+		{name: "version_flag", args: []string{"--version"}, want: false},
+		{name: "version_not_first", args: []string{"--env", ".env", "version"}, want: false},
+		{name: "other_args", args: []string{"--env", ".env"}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, isVersionCommand(tt.args))
+		})
+	}
+}
+
+func TestPrintVersion(t *testing.T) {
+	t.Parallel()
+
+	buf := &bytes.Buffer{}
+
+	printVersion(buf)
+
+	assert.Equal(t, "GameAP "+defaults.Version+"\nBuild date: "+defaults.BuildDate+"\n", buf.String())
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added version information output through the `gameap version` command and `-version` or `--version` flags.
  * Displays the application version and build date before exiting.

* **Tests**
  * Added coverage for supported and invalid version command formats.
  * Added validation for version and build date output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->